### PR TITLE
use sesquilinear.v instead of forms.v

### DIFF
--- a/derive_matrix.v
+++ b/derive_matrix.v
@@ -3,8 +3,9 @@ From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum rat.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import interval_inference.
 From mathcomp Require Import realalg complex fingroup perm.
+From mathcomp Require Import sesquilinear.
 From mathcomp Require Import boolp reals classical_sets.
-From mathcomp Require Import topology normedtype landau forms derive.
+From mathcomp Require Import topology normedtype landau derive.
 From mathcomp Require Import functions.
 Require Import ssr_ext euclidean rigid skew.
 

--- a/dh.v
+++ b/dh.v
@@ -2,11 +2,10 @@
 From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import realalg complex fingroup perm.
+From mathcomp Require Import sesquilinear.
 From mathcomp Require Import interval reals trigo.
 Require Import ssr_ext euclidean skew vec_angle rot frame rigid.
 Require Import extra_trigo.
-
-From mathcomp.analysis Require Import forms.
 
 (******************************************************************************)
 (*                       Denavit-Hartenberg convention                        *)

--- a/differential_kinematics.v
+++ b/differential_kinematics.v
@@ -2,8 +2,9 @@
 From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum rat.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import realalg complex fingroup perm.
+From mathcomp Require Import sesquilinear.
 From mathcomp Require Import boolp reals classical_sets signed.
-From mathcomp Require Import topology normedtype landau forms derive.
+From mathcomp Require Import topology normedtype landau derive.
 From mathcomp Require Import functions.
 Require Import ssr_ext derive_matrix euclidean frame rot skew rigid.
 
@@ -33,6 +34,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 Import Order.TTheory GRing.Theory Num.Def Num.Theory.
+Import numFieldNormedType.Exports.
 
 Local Open Scope ring_scope.
 Local Open Scope frame_scope.
@@ -762,15 +764,22 @@ rewrite (mul_mx_row _ a) {}/a; congr (@row_mx _ _ 3 3 _ _).
     rewrite /scara_joint_velocities /scara_joint_variables derive1mxE /geo_jac_lin /=.
     apply/rowP => i; rewrite 3![in RHS]mxE [in LHS]mxE sum4E;
           (repeat apply: f_equal2).
-    - by rewrite 2!mxE /= linearZl_LR [in RHS]mxE.
-    - by rewrite 2!mxE /= linearZl_LR [in RHS]mxE.
+    - rewrite 2!mxE /=.
+      rewrite (linearZl_LR _ (\o{Fmax t} - \o{Fim1``_t}))/=.
+      by rewrite [in RHS]mxE.
+    - rewrite 2!mxE /=.
+      rewrite (linearZl_LR _ (\o{Fmax t} - \o{Fim1 1 t}))/=.
+      by rewrite [in RHS]mxE.
     - by rewrite 2!mxE [in RHS]mxE.
-    - by rewrite 2!mxE /= linearZl_LR [in RHS]mxE.
+    - rewrite 2!mxE /=.
+      by rewrite (linearZl_LR _ (\o{Fmax t} - \o{Fim1 3 t}))/= [in RHS]mxE.
   rewrite o0E subr0.
   rewrite {1}o4E.
-  rewrite linearDr /=.
-  rewrite (linearZr_LR _ _ _ 'e_2)
-   /= {2}Hzvec (linearZl_LR _ _ _ 'e_2) /= (@liexx _ (vec3 R)) 2!{1}scaler0 addr0.
+  rewrite (linearDr _ (_ *: Fim1``_t|,2)) /=.
+  rewrite (linearZr_LR _ _ d4)/=.
+  rewrite {2}Hzvec.
+  rewrite (linearZl_LR _ _ (_ t) 'e_2) /=.
+  rewrite (@liexx _ (vec3 R)) 2!{1}scaler0 addr0.
   rewrite (_ : \o{Fmax t} - \o{Fim1 1 t} =
     (a2 * cos (theta1 t + theta2 t) *: 'e_0 +
     (a1 * sin (theta1 t) + a2 * sin (theta1 t + theta2 t) - a1 * sin (theta1 t)) *: 'e_1 +
@@ -781,17 +790,23 @@ rewrite (mul_mx_row _ a) {}/a; congr (@row_mx _ _ 3 3 _ _).
     rewrite -3!addrA addrC 3!addrA subrK.
     rewrite addrC -[in RHS]addrA; congr (_ + _).
     by rewrite -addrA -scalerDl.
-  rewrite linearDr /=.
-  rewrite (linearZr_LR _ _ _ 'e_2) /= (linearZl_LR crossmul 'e_2)
-          {2}(Hzvec t 1) /= (@liexx _ (vec3 R)) 2!{1}scaler0 addr0.
+  rewrite (linearDr _ ((theta2^`())%classic t *: (Fim1 1 t)|,2))/=.
+  rewrite (linearZr_LR _ _ (d3 t + d4))/=.
+  rewrite (linearZl_LR _ _ _ (Fim1 1 t)|,2)/=.
+  rewrite (linearZl_LR _ _ _ (Fim1 1 t)|,2)/=.
+  rewrite {2}(Hzvec t 1)/=.
+  rewrite (@liexx _ (vec3 R))/= 2!{1}scaler0 addr0.
   rewrite (addrC (a1 * sin _)) addrK.
   rewrite (_ : \o{Fmax t} - \o{Fim1 3%:R t} = d4 *: 'e_2%:R); last first.
     by rewrite o4E -addrA addrC subrK.
-  rewrite (linearZr_LR _ _ _ 'e_2) /= (linearZl_LR crossmul 'e_2)
-          {1}(Hzvec t 3%:R) /= (@liexx _ (vec3 R)) 2!scaler0 addr0.
+  rewrite (linearZr_LR _ _ d4 'e_2) /=.
+  rewrite (linearZl_LR _ _ _ (Fim1 3 t)|,2)/=.
+  rewrite {1}(Hzvec t 3%:R) /= (@liexx _ (vec3 R)) 2!scaler0 addr0.
   rewrite o3E.
-  rewrite linearDr /= (linearZr_LR _ _ _ 'e_2) (linearZl_LR _ 'e_2)
-          {2}(Hzvec t 0) /= (@liexx _ (vec3 R)) 2!scaler0 addr0.
+  rewrite (linearDr _ ((theta1^`())%classic t *: Fim1``_t|,2)) /=.
+  rewrite (linearZr_LR _ _ (d3 t) 'e_2)/=.
+  rewrite [in X in _ + X + _ + _ ](linearZl_LR _ _ ((theta1^`())%classic t) Fim1``_t|,2)/=.
+  rewrite {2}(Hzvec t 0) /= (@liexx _ (vec3 R)) 2!scaler0 addr0.
   rewrite {1}o2E {1}o1E.
   rewrite (_ : (fun _ => _) =
                 (a2 \*: (cos \o (theta2 + theta1) : R^o -> R^o)) +
@@ -804,9 +819,18 @@ rewrite (mul_mx_row _ a) {}/a; congr (@row_mx _ _ 3 3 _ _).
       exact: ex_derive.
       exact: H3.
     by rewrite deriveE // diff_cst add0r derive1E.
-  - rewrite !linearDr /= !(linearZr_LR crossmul)
-            !(linearZl_LR crossmul) /= !Hzvec veckj vecki
-            !{1}scalerN.
+  - rewrite 3!(linearDr _ ((theta1^`())%classic t *: Fim1``_t|,2))/=.
+    rewrite (linearDr _ (Fim1 1 t)|,2)/=.
+    rewrite (linearZr_LR _ _ (a1 * cos (theta1 t)))/=.
+    rewrite (linearZr_LR _ _ (a1 * sin (theta1 t)))/=.
+    rewrite (linearZr_LR _ _ (a2 * cos (theta1 t + theta2 t)))/=.
+    rewrite (linearZr_LR _ _ (a2 * sin (theta1 t + theta2 t)))/=.
+    rewrite 2!(linearZl_LR _ _ ((theta1^`())%classic t))/=.
+    rewrite (linearZr_LR _ _ (a2 * cos (theta1 t + theta2 t)))/=.
+    rewrite (linearZr_LR _ _ (a2 * sin (theta1 t + theta2 t)))/=.
+    rewrite !Hzvec veckj vecki.
+    rewrite !{1}scalerN.
+    rewrite scalerBr.
     rewrite -!addrA addrCA addrC -!addrA (addrCA (- _)) !addrA.
     rewrite -2!addrA [in RHS]addrC; congr (_ + _).
     - rewrite !scalerA -2!scalerDl row3e1; congr (_ *: _).
@@ -823,14 +847,17 @@ rewrite (mul_mx_row _ a) {}/a; congr (@row_mx _ _ 3 3 _ _).
       rewrite -derive1E [in RHS]derive1_comp; last 2 first.
       - exact: H1.
       - exact: derivable_sin.
-      rewrite derive1_sin -addrA addrC; congr (_ + _); last first.
+      rewrite derive1_sin -addrA addrC; congr +%R; last first.
         by rewrite -mulrA.
-      rewrite -mulrDr [in RHS]derive1E deriveD; last 2 first.
+      rewrite[in RHS]derive1E deriveD; last 2 first.
         exact: H2.
         exact: H1.
-      rewrite -mulrA scale_realType; apply: f_equal2; first by [].
-      rewrite addrC; apply: f_equal2; first by [].
-      by rewrite addrC !derive1E.
+      rewrite -mulrA scale_realType.
+      rewrite !mulrDr [LHS]addrC; congr +%R.
+        rewrite mulrC -mulrA.
+        rewrite derive1E.
+        by rewrite addrC.
+      by rewrite derive1E addrC.
     - rewrite !{1}scalerA !addrA -3!{1}scaleNr -2!scalerDl row3e0.
       congr (_ *: _).
       rewrite [in RHS]derive1E deriveD; last 2 first.
@@ -852,9 +879,8 @@ rewrite (mul_mx_row _ a) {}/a; congr (@row_mx _ _ 3 3 _ _).
       rewrite [in RHS]derive1E deriveD; last 2 first.
         exact: H2.
         exact: H1.
-      rewrite -mulrDr -!derive1E.
-      rewrite addrC (addrC (_^`() _)%classic).
-      by rewrite !scalerAl.
+      rewrite [X in _ + X = _]mulrC -mulrDr !derive1E -mulrA.
+      by rewrite addrC (addrC ('D__ _ _)).
 - rewrite /scara_ang_vel (_ : @rot_of_hom R \o _ = rot); last first.
     rewrite funeqE => x /=; exact: rot_of_hom_hom.
   rewrite /rot /ang_vel /scara_rot.

--- a/euclidean.v
+++ b/euclidean.v
@@ -1,9 +1,10 @@
 (* coq-robot (c) 2017 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From HB Require Import structures.
 From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum rat poly.
+From mathcomp Require Import sesquilinear.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import realalg complex fingroup perm.
-From mathcomp Require Import reals forms.
+From mathcomp Require Import reals.
 Require Import ssr_ext.
 
 (******************************************************************************)
@@ -94,9 +95,7 @@ Qed.
 End liealgebra.
 
 Section dot_product0.
-
 Variables (R : ringType) (n : nat).
-
 Implicit Types u v w : 'rV[R]_n.
 
 Definition dotmul u v : R := (u *m v^T) ``_ 0.
@@ -166,7 +165,6 @@ Lemma mxE_dotmul (M : 'M[R]_n) i j : M i j = 'e_j *d row i M.
 Proof. by rewrite mxE_col_row /dotmul colE. Qed.
 
 End dot_product0.
-
 Notation "*d%R" := (@dotmul _ _) : ring_scope.
 Notation "u *d w" := (dotmul u w) : ring_scope.
 
@@ -1663,7 +1661,9 @@ rewrite [X in _ + _ + X](_ : _ = - M 0 2%:R * M 2%:R 0); last first.
   rewrite [in X in X * _]/=.
   rewrite coefD coefM sum2E subn0 coefC coefC mulr0 add0r.
   rewrite coefC mul0r add0r coefM sum2E subn0 subnn coefC [in X in X * _`_1]/=.
-  by rewrite coefD coefX coefN coefC subr0 mulr1 coefC mul0r addr0 coefC mul0r addr0 mulNr.
+  rewrite !coefD !coefX !coefN !coefC/=.
+  rewrite !mul0r !addr0/= subr0 mulr1.
+  by rewrite mulNr.
 rewrite /Z.
 apply/(@mulrI _ 2%:R); first exact: pnatf_unit.
 rewrite mulrA div1r divrr ?pnatf_unit // mul1r.

--- a/octonion.v
+++ b/octonion.v
@@ -3,7 +3,7 @@ From HB Require Import structures.
 From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import realalg complex fingroup perm.
-From mathcomp.analysis Require Import forms.
+From mathcomp Require Import sesquilinear.
 From mathcomp Require Import interval reals.
 
 Require Import ssr_ext euclidean vec_angle frame rot quaternion.

--- a/quaternion.v
+++ b/quaternion.v
@@ -2,11 +2,11 @@
 From HB Require Import structures.
 From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
+From mathcomp Require Import sesquilinear.
 From mathcomp Require Import ring.
 From mathcomp Require Import realalg complex fingroup perm.
 From mathcomp Require Import interval reals trigo.
 Require Import ssr_ext euclidean vec_angle frame rot.
-From mathcomp.analysis Require Import forms.
 Require Import extra_trigo.
 
 (******************************************************************************)
@@ -84,9 +84,6 @@ Unset Printing Implicit Defensive.
 Local Open Scope ring_scope.
 
 Import Order.TTheory GRing.Theory Num.Def Num.Theory.
-
-(* TODO: overrides forms.v *)
-Notation "u '``_' i" := (u (@GRing.zero _) i) : ring_scope.
 
 Section quaternion0.
 Variable R : ringType.
@@ -242,14 +239,14 @@ Lemma mul1q : left_id 1%:q mulq.
 Proof.
 case=> a a'; rewrite /mulq /=; congr mkQuat; Simp.r => /=.
   by rewrite dotmul0v subr0.
-by rewrite linear0l addr0.
+by rewrite (linear0l _ a') addr0.
 Qed.
 
 Lemma mulq1 : right_id 1%:q mulq.
 Proof.
 case=> a a'; rewrite /mulq /=; congr mkQuat; Simp.r => /=.
   by rewrite dotmulv0 subr0.
-by rewrite linear0r addr0.
+by rewrite (linear0r _ a') addr0.
 Qed.
 
 Lemma mulqDl : left_distributive mulq (@addq R).
@@ -296,7 +293,11 @@ Lemma realqE x : x \is realq R -> x = (x.1)%:q.
 Proof. by rewrite qualifE; case: x => [x1 x2] /= /eqP->. Qed.
 
 Lemma quat_realM (r s : R) : (r * s)%:q = r%:q * s%:q.
-Proof. by congr mkQuat; rewrite /= (dotmul0v, linear0l); Simp.r. Qed.
+Proof.
+congr mkQuat; rewrite /= ?dotmul0v ?subr0// !scaler0.
+rewrite !add0r.
+by rewrite (@liexx _ (vec3 R)).
+Qed.
 
 Lemma iiN1 : `i * `i = -1.
 Proof. by congr mkQuat; rewrite (dote2, @liexx _ (vec3 R)) /=; Simp.r. Qed.
@@ -360,7 +361,7 @@ case: x y => [x1 x2] [y1 y2]; apply/eqP.
 rewrite !mulqE /mulq /= scaleqE /= eq_quat /=.
 apply/andP; split; first by Simp.r; rewrite mulrBr mulrA dotmulZv.
 apply/eqP; Simp.r; rewrite 2!scalerDr scalerA -2!addrA; congr (_ + _).
-by rewrite linearZl_LR /=; congr (_ + _); rewrite scalerA mulrC -scalerA.
+by rewrite (linearZl_LR _ y2)/=; congr (_ + _); rewrite scalerA mulrC -scalerA.
 Qed.
 
 HB.instance Definition _ := @GRing.Lmodule_isLalgebra.Build R (quat R) quatAl.
@@ -372,7 +373,7 @@ rewrite !mulqE /mulq /= scaleqE /= eq_quat /=.
 apply/andP; split; first by Simp.r; rewrite /= mulrBr mulrCA mulrA dotmulvZ.
 apply/eqP; Simp.r; rewrite 2!scalerDr !scalerA.
 rewrite (mulrC k); congr (_ + _ + _).
-by rewrite linearZr_LR/=.
+by rewrite (linearZr_LR _ x2)/=.
 Qed.
 
 HB.instance Definition _ := @GRing.Lalgebra_isAlgebra.Build _ (quat R) quatAr.
@@ -998,8 +999,6 @@ HB.instance Definition _ x := @GRing.isLinear.Build _ _ _ _ _ (quat_rot_is_linea
 Lemma quat_rot_isRot_polar v a : norm v = 1 ->
   isRot (a *+2) v (quat_rot (quat_of_polar a v)).
 Proof.
-Set Printing All.
-Show Proof.
 move=> v1 /=.
 have vE : (Base.frame v)~i = v by rewrite Base.frame0E // ?normalizeI // norm1_neq0.
 apply/isRotP; split => /=.
@@ -1284,7 +1283,8 @@ Fact invdE x : x \in unitd ->
   invd x = dual_of_mat (x.1^-1%:M * (1 - deps R * x.2%:M * (x.1)^-1%:M)).
 Proof.
 move : x => [q r] /=; rewrite inE /= => qu; rewrite /invd inE /= qu.
-by rewrite /dual_of_mat !(mxE,sum2E) /=; Simp.r.
+rewrite /dual_of_mat !(mxE,sum2E) /=; Simp.r.
+by rewrite /= mulr1.
 Qed.
 
 Lemma mulVd : {in unitd, left_inverse 1 invd *%R}.

--- a/scara.v
+++ b/scara.v
@@ -2,9 +2,10 @@
 From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import realalg complex fingroup perm.
+From mathcomp Require Import sesquilinear.
 From mathcomp Require Import interval reals trigo.
 Require Import ssr_ext euclidean skew vec_angle rot frame rigid screw.
-From mathcomp Require Import reals forms.
+From mathcomp Require Import reals.
 Require Import extra_trigo.
 
 (******************************************************************************)
@@ -67,7 +68,7 @@ rewrite /A21.
 rewrite homM RzM mulmx_row3_col3 !scale0r !add0r e2row !row3Z row3D. Simp.r.
 rewrite homM RzM addrC (addrC _ theta2) addrA; congr hom.
 rewrite mulmx_row3_col3 e2row !row3Z !row3D. Simp.r.
-by rewrite -!mulrA -mulrBr -cosD -mulrDr (addrC (_ * sin theta1)) -sinD/= add0r.
+by rewrite -!mulrA -mulrBr -cosD -mulrDr (addrC (_ * sin theta1)) -sinD/=.
 Qed.
 
 End hom_scara.
@@ -113,7 +114,10 @@ Definition g := g0 * `e$(theta4, t4) *
 
 Lemma S1 : `e$(theta1, t1) = hRz theta1.
 Proof.
-rewrite /t1 /rjoint_twist linearNl /= linear0r oppr0 etwist_Rz; last first.
+rewrite /t1 /rjoint_twist.
+rewrite (linearNl _ q1)/=.
+rewrite (linear0r _ w1)/=.
+rewrite oppr0 etwist_Rz; last first.
   by rewrite -norm_eq0 normeE oner_eq0.
 by rewrite -Rz_eskew.
 Qed.
@@ -123,7 +127,9 @@ Lemma point_axis_twist (d : R) :
   \pt( axis \T((- 'e_2%:R *v row3 d 0 0), 'e_2%:R) ) = row3 d 0 0.
 Proof.
 rewrite {1}/axis ang_tcoorE (negbTE (norm1_neq0 (normeE _ _))) /=.
-rewrite normeE expr1n invr1 scale1r lin_tcoorE linearNl linearNr /=.
+rewrite normeE expr1n invr1 scale1r lin_tcoorE.
+rewrite (linearNl _ ((row3 d)``_0))/=.
+rewrite (linearNr _ ('e_2))/=.
 rewrite double_crossmul dotmulvv normeE expr1n scale1r /w2 /q2 e2row.
 rewrite dotmulE sum3E !mxE /=. by Simp.r.
 Qed.
@@ -165,7 +171,7 @@ rewrite (addrC _ (a1 * (1 - cos theta2))) mulrBr mulr1 mulrDl !addrA subrK.
 rewrite mulrDl addrAC subrr add0r.
 rewrite homM RzM mulmx_row3_col3 e2row !row3Z !row3D. Simp.r.
 rewrite addrC (addrC theta4) addrA; congr hom.
-rewrite /scara_trans/= !add0r; congr row3.
+rewrite /scara_trans/=; congr row3.
 - by rewrite mulrDl -addrA -!mulrA -mulrBr -cosD addrC.
 - by rewrite mulrDl -addrA -!mulrA -mulrDr (addrC (cos theta2 * _)) -sinD addrC.
 Qed.

--- a/screw.v
+++ b/screw.v
@@ -3,7 +3,7 @@ From HB Require Import structures.
 From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import realalg complex fingroup perm.
-From mathcomp.analysis Require Import forms.
+From mathcomp Require Import sesquilinear.
 From mathcomp Require Import interval reals trigo.
 Require Import ssr_ext euclidean skew vec_angle frame rot rigid extra_trigo.
 
@@ -102,8 +102,9 @@ Proof. by rewrite ecoefS ecoefM0 mulr1 invr1 scale1r. Qed.
 Lemma tr_ecoef M k : (ecoef M k)^T = ecoef M^T k.
 Proof.
 elim: k => [|k ih]; first by rewrite 2!ecoefM0 trmx1.
-rewrite ecoefS -mulmxE -scalemxAl linearZ /= trmx_mul ih ecoefS.
-rewrite -mulmxE -scalemxAl; congr (_ *: _).
+rewrite ecoefS -mulmxE -scalemxAl linearZ /=.
+rewrite trmx_mul ih ecoefS.
+rewrite -mulmxE -[in RHS]scalemxAl; congr (_ *: _).
 by rewrite /ecoef -scalemxAr -scalemxAl !mulmxE -exprSr -exprS.
 Qed.
 
@@ -560,12 +561,14 @@ Definition inv_rigid_trans w v := hom 1 (- v *v w).
 
 Lemma Vrigid_trans w v : inv_rigid_trans w v * rigid_trans w v = 1.
 Proof.
-by rewrite /inv_rigid_trans /rigid_trans homM mulr1 mulmx1 addrC linearNl subrr hom10.
+rewrite /inv_rigid_trans /rigid_trans homM mulr1 mulmx1 addrC.
+by rewrite (linearNl _ w)/= subrr hom10.
 Qed.
 
 Lemma rigid_transV w v : rigid_trans w v * inv_rigid_trans w v = 1.
 Proof.
-by rewrite /inv_rigid_trans /rigid_trans homM mulr1 mulmx1 linearNl subrr hom10.
+rewrite /inv_rigid_trans /rigid_trans homM mulr1 mulmx1.
+by rewrite (linearNl _ w)/= subrr hom10.
 Qed.
 
 End sample_rigid_transformation.
@@ -629,7 +632,9 @@ move=> w1 g h.
 rewrite inv_rigid_transE /inv_rigid_trans /rigid_trans.
 rewrite /wedge !Twist.ang_of !Twist.lin_of.
 rewrite (mulmx_block 1 0 (- _ *v _) 1 \S( w )) !(mulmx0,addr0,mul0mx,mul1mx).
-rewrite spinE linearNl linearNr /=.
+rewrite spinE.
+rewrite (linearNl _ w)/=.
+rewrite (linearNr _ w)/=.
 rewrite double_crossmul dotmulvv w1 expr1n scale1r opprB subrK.
 by rewrite (mulmx_block \S( w ) 0 _ 0 1 0) !(mulmx0,addr0,mul0mx,mul1mx,mulmx1).
 Qed.
@@ -658,10 +663,12 @@ rewrite /wedge Twist.ang_of Twist.lin_of.
 elim: k => [|k ih].
   rewrite (@expr2 _ (block_mx \S( w ) _ _ _)) -mulmxE.
   rewrite (mulmx_block \S( w ) _ _ _ \S( w )).
-  by rewrite !(mulmx0,addr0,mul0mx) mulmxE -expr2 spinE linearZr_LR (@liexx _ (vec3 T))/= scaler0.
+  rewrite !(mulmx0,addr0,mul0mx) mulmxE -expr2 spinE.
+  by rewrite (linearZr_LR _ w)/= (@liexx _ (vec3 T))/= scaler0.
 rewrite exprS ih -mulmxE (mulmx_block \S( w ) _ _ _ (\S( w ) ^+ k.+2)).
 rewrite !(mulmx0,addr0,mul0mx) mulmxE -exprS; congr (block_mx (\S( w ) ^+ k.+3) 0 _ 0).
-by rewrite exprS mulmxA spinE linearZr_LR/= (@liexx _ (vec3 T)) scaler0 mul0mx.
+rewrite exprS mulmxA spinE.
+by rewrite (linearZr_LR _ w)/= (@liexx _ (vec3 T)) scaler0 mul0mx.
 Qed.
 
 Lemma emx2_twist w v a : norm w = 1 ->
@@ -680,8 +687,10 @@ rewrite {1}/g /rigid_trans mulmxE homM mul1r.
 rewrite inv_rigid_transE /inv_rigid_trans homM mulr1 mulmx1 emx2.
 rewrite -spinZ.
 congr (block_mx (1 + \S( a *: w )) 0 _ 1).
-rewrite mulmxDr mulmx1 linearNl -addrA addrC addrA subrK spinE.
-rewrite scalerA (mulrC h) -scalerA /= linearZl_LR /= -scalerDr; congr (_ *: _).
+rewrite mulmxDr mulmx1.
+rewrite (linearNl _ w) -addrA addrC addrA subrK spinE.
+rewrite scalerA (mulrC h) -scalerA /=.
+rewrite (linearZl_LR _ (v *v w))/= -scalerDr; congr (_ *: _).
 by rewrite double_crossmul dotmulvv w1 expr1n scale1r -/h addrCA subrr addr0.
 Qed.
 
@@ -741,12 +750,13 @@ rewrite /emx_twist /hom_twist.
 
 rewrite ang_tcoorE (negbTE w0) [in RHS]spinZ; congr hom.
 
-rewrite linearZl_LR /= linearZr_LR /= scalerA.
+rewrite (linearZl_LR _ (normalize w))/=.
+rewrite (linearZr_LR _ v) /= scalerA.
 rewrite dotmulZv dotmulvZ !mulrA -[in X in _ + X + _]scalerA.
 rewrite /normalize.
-rewrite (linearZr_LR crossmul _ _ w) /=.
-rewrite linearNl /=.
-rewrite (linearZl_LR crossmul) /=.
+rewrite (linearZr_LR _ _ _ w) /=.
+rewrite (linearNl _ w) /=.
+rewrite (linearZl_LR _ w) /=.
 rewrite [in X in _ + _ + X = _]scalerN.
 rewrite [in X in _ + _ + X]scalerA.
 rewrite -[in LHS]scalemxAl -scalerDr -scalerBr; congr (_ *: _).
@@ -1087,15 +1097,18 @@ Proof.
 move=> l a h q w v.
 rewrite /etwist /hom_twist.
 case: ifPn => [/eqP|]; rewrite ang_tcoorE => w0.
-  by rewrite hom_screww0 // /v lin_tcoorE w0 linearNl /= linear0l oppr0 scaler0 addr0 scaler0.
+  rewrite hom_screww0 // /v lin_tcoorE w0.
+  rewrite (linearNl _ q)/=.
+  rewrite (linear0l _ q).
+  by rewrite oppr0 scaler0 addr0 scaler0.
 rewrite /hom_screw_motion.
 rewrite -/l -/a -/h -/q -/w.
 congr hom.
 rewrite {1}/v.
 rewrite lin_tcoorE.
 rewrite [w *v _]linearD /=.
-rewrite linearZr_LR /= (@liexx _ (vec3 T)) scaler0 addr0.
-rewrite linearNl linearNr /=.
+rewrite (linearZr_LR _ w) /= (@liexx _ (vec3 T)) scaler0 addr0.
+rewrite (linearNl _ q)/= (linearNr _ w)/=.
 rewrite double_crossmul dotmulvv.
 rewrite [in X in _ = _ *: (X + _)]mulNmx.
 rewrite [in X in _ = _ *: (X + _)]mulmxBl.
@@ -1118,7 +1131,7 @@ rewrite mulrC -[LHS]addr0.
 congr (_ + _).
 rewrite mulmxBr mulmx1.
 rewrite -rodriguesP /rodrigues.
-rewrite linearZr_LR /= (@liexx _ (vec3 T)) 2!scaler0 addr0.
+rewrite (linearZr_LR _ w)/= /= (@liexx _ (vec3 T)) 2!scaler0 addr0.
 rewrite dotmulZv dotmulvv.
 rewrite !scalerA mulrAC -mulrA opprB subrK.
 apply/esym/eqP; rewrite scaler_eq0; apply/orP; right.
@@ -1147,7 +1160,7 @@ Definition axis (t : twist T) : Line.t T :=
 Lemma point_axis_nolin w : w != 0 -> \pt( axis \T(0, w) ) = 0.
 Proof.
 move=> w0; rewrite /axis ang_tcoorE (negbTE w0) /=.
-by rewrite lin_tcoorE /= linear0r scaler0.
+by rewrite lin_tcoorE /= (linear0r _ w) scaler0.
 Qed.
 
 (* [murray] 2.42, p.47 *)
@@ -1165,7 +1178,8 @@ Definition pjoint_twist (v : vector) := \T(v, 0).
 Lemma pitch_perp (w u : 'rV[T]_3) : norm w = 1 -> pitch (rjoint_twist w u) = 0.
 Proof.
 move=> w1; rewrite /pitch ang_tcoorE lin_tcoorE w1 expr1n invr1 scale1r.
-by rewrite (@lieC _ (vec3 T)) linearNr opprK -dot_crossmulC (@liexx _ (vec3 T)) dotmulv0.
+rewrite (@lieC _ (vec3 T))/=.
+by rewrite (linearNr _ u)/= opprK -dot_crossmulC (@liexx _ (vec3 T)) dotmulv0.
 Qed.
 
 (* [murray] 2.44, p.48 *)
@@ -1239,7 +1253,9 @@ set q := \pt( l ).
 set v := - w *v q + h *: w.
 case/boolP : (w == 0) => [/eqP|]w0.
   exists \T(v, 0).
-  by rewrite /v w0 oppr0 linear0l add0r scaler0 etwistv0 hom_screww0.
+  rewrite /v w0 oppr0.
+  rewrite (linear0l _ q).
+  by rewrite add0r scaler0 etwistv0 hom_screww0.
 exists \T(v, w).
 by rewrite hom_screw_motion_etwist -/a -/w -/q -/h -/v.
 Qed.
@@ -1680,13 +1696,19 @@ congr (@block_mx _ 1 0 3 3).
     rewrite /map_v coortrans_vectorE scalemxAl.
     by rewrite EuclideanMotion.rot_inv.
   rewrite /map_p coortrans_pointE from_hD to_hpointK.
-  rewrite linearDr /=; congr (_ + _).
+  rewrite (linearDr _ (- map_v w_a))/=; congr (_ + _).
     rewrite /map_v coortrans_vectorE EuclideanMotion.rot_inv.
-    rewrite !(linearNl crossmul) /= mulNmx; congr (- _).
+    rewrite (linearNl _ (from_h (q_a *m row_mx (EuclideanMotion.rot g_ab)^T 0)))/=.
+    rewrite (linearNl _ q_a)/=.
+    rewrite !mulNmx.
+    congr (- _).
     rewrite mul_mx_row mulmx0 to_hvectorK -mulmxr_crossmulr_SO //.
     by rewrite rotationV EuclideanMotion.rotP.
   rewrite /map_v coortrans_vectorE EuclideanMotion.rot_inv.
-  rewrite EuclideanMotion.trans_inv mulNmx linearNl linearNr /= opprK.
+  rewrite EuclideanMotion.trans_inv mulNmx.
+  rewrite (linearNl _ (- (EuclideanMotion.trans g_ab *m (EuclideanMotion.rot g_ab)^T)))/=.
+  rewrite (linearNr _ (w_a *m (EuclideanMotion.rot g_ab)^T))/=.
+  rewrite opprK.
   rewrite -spin_similarity; last by rewrite rotationV EuclideanMotion.rotP.
   rewrite trmxK mulrA mulNr -mulmxE mulmxA orthogonal_tr_mul ?mul1mx; last first.
     by rewrite rotation_sub // EuclideanMotion.rotP.

--- a/skew.v
+++ b/skew.v
@@ -2,9 +2,10 @@
 From HB Require Import structures.
 From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
+From mathcomp Require Import sesquilinear.
 From mathcomp Require Import realalg complex finset fingroup perm ring.
 Require Import ssr_ext euclidean vec_angle.
-From mathcomp Require Import forms reals.
+From mathcomp Require Import reals.
 
 (******************************************************************************)
 (*                         Skew-symmetric matrices                            *)
@@ -35,9 +36,6 @@ Reserved Notation "'\S(' w ')'" (at level 3, format "'\S(' w ')'").
 Reserved Notation "''so[' R ]_ n" (at level 8, n at level 2, format "''so[' R ]_ n").
 
 Local Open Scope ring_scope.
-
-(* TODO: overrides forms.v *)
-Notation "u '``_' i" := (u (@GRing.zero _) i) : ring_scope.
 
 Section keyed_qualifiers_anti_sym.
 
@@ -277,7 +275,13 @@ Proof.
 rewrite (@lieC _ (vec3 R)) -linearNr [RHS]lieC/= -linearNr [u]row_sum_delta/=.
 rewrite -/(mulmxr _ _) !linear_sum /=; apply: eq_bigr=> i _.
 rewrite /spin; unlock.
-by rewrite !linearZ /= -scalemxAl -rowE linearN /= rowK linearNl opprK.
+rewrite 2!linearZ/=.
+rewrite -scalemxAl -rowE.
+rewrite (linearNr _ (- v))/=.
+rewrite (@lieC _ (vec3 R)) opprK/=.
+rewrite rowK.
+rewrite (@lieC _ (vec3 R))/=.
+by rewrite [in RHS]linearN/=.
 Qed.
 
 Lemma spin0 : \S( 0 ) = 0.
@@ -420,7 +424,8 @@ Lemma spin_crossmul u v : \S(v *v u) = \S(u) *m \S(v) - \S(v) *m \S(u).
 Proof.
 apply/eqP/mulmxP => w.
 rewrite [in LHS]spinE mulmxBr !mulmxA ![in RHS]spinE.
-rewrite (@lieC _ (vec3 R) v w) linearNr opprK.
+rewrite (@lieC _ (vec3 R) v w)/=.
+rewrite linearN/= opprK.
 move/eqP: (@jacobi _ (vec3 R) v u w); rewrite eq_sym -subr_eq eq_sym => /eqP -> /=.
 by rewrite add0r (@lieC _ (vec3 R) w) opprK.
 Qed.

--- a/ssr_ext.v
+++ b/ssr_ext.v
@@ -83,7 +83,7 @@ Ltac r := rewrite ?(Monoid.simpm,
                     mulr0,mul0r,mul1r,mulr1,addr0,add0r,
                     mulr1n,mulNr,mulrN,opprK,oppr0,
                     scale0r, scaler0, scaleN1r, scale1r,
-                    eqxx).
+                    eqxx)/=.
 
 End Simp.
 


### PR DESCRIPTION
This PR gives up on `forms.v` (that is still in the released versions of MathComp-Analysis but that is scheduled to disappear in the next version) and use `sesquilinear.v` from MathComp >= 2.3.0 instead.

There are significant performance issues with most rewrite's using `linearNl`, `linearZl_LR`, etc. that are "solved" by passing arguments to the lemmas when rewriting (which defeats a bit the purpose of having generic lemmas).

@CohenCyril