### PR TITLE
norm -> enorm

### DIFF
--- a/dh.v
+++ b/dh.v
@@ -1,4 +1,4 @@
-(* coq-robot (c) 2017 AIST and INRIA. License: LGPL-2.1-or-later. *)
+(* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import realalg complex fingroup perm.
@@ -54,7 +54,7 @@ Implicit Types l : Line.t T.
 
 Definition normalized_plucker_direction l :=
   let p1 := \pt( l ) in let p2 := \pt2( l ) in
-  (norm (p2 - p1))^-1 *: (p2 - p1).
+  (`|p2 - p1|_e)^-1 *: (p2 - p1).
 
 Lemma normalized_plucker_directionP (l : Line.t T) : \vec( l ) != 0 ->
   let e := normalized_plucker_direction l in e *d e == 1.
@@ -62,8 +62,8 @@ Proof.
 move=> l0 /=.
 rewrite /normalized_plucker_direction dotmulZv dotmulvZ dotmulvv.
 rewrite -Line.vectorE.
-rewrite mulrA mulrAC expr2 mulrA mulVr ?unitfE ?norm_eq0 // mul1r.
-by rewrite divrr // unitfE norm_eq0.
+rewrite mulrA mulrAC expr2 mulrA mulVr ?unitfE ?enorm_eq0// mul1r.
+by rewrite divrr // unitfE enorm_eq0.
 Qed.
 
 Definition normalized_plucker_position l :=
@@ -88,22 +88,22 @@ Lemma normalized_pluckerP l :
   let p1 := \pt( l ) in
   let p2 := \pt2( l ) in
   \vec( l ) != 0 ->
-  plucker_of_line l = norm (p2 - p1) *: normalized_plucker l.
+  plucker_of_line l = `|p2 - p1|_e *: normalized_plucker l.
 Proof.
 move=> p1 p2 l0.
 rewrite /normalized_plucker /normalized_plucker_direction /normalized_plucker_position.
 rewrite -/p1 -/p2 (linearZr_LR crossmul) -scale_row_mx scalerA.
-by rewrite divrr ?scale1r // unitfE norm_eq0 /p2 -Line.vectorE.
+by rewrite divrr ?scale1r // unitfE enorm_eq0 /p2 -Line.vectorE.
 Qed.
 
 Lemma plucker_of_lineE l (l0 : \vec( l ) != 0) :
-  plucker_of_line l = norm (\pt2( l ) - \pt( l )) *:
+  plucker_of_line l = `|\pt2( l ) - \pt( l )|_e *:
   (Plucker.mkArray (normalized_plucker_directionP l0) (normalized_plucker_positionP l) : 'M__).
 Proof.
 rewrite /plucker_of_line /plucker_array_mx /=.
 rewrite /normalized_plucker_direction /normalized_plucker_position.
 rewrite (linearZr_LR crossmul) -scale_row_mx.
-by rewrite scalerA divrr ?scale1r // unitfE norm_eq0 -Line.vectorE.
+by rewrite scalerA divrr ?scale1r // unitfE enorm_eq0 -Line.vectorE.
 Qed.
 
 Definition plucker_eqn p l :=
@@ -196,7 +196,7 @@ Variables F0 F1 : tframe T.
 Definition From1To0 := locked (F1 _R^ F0).
 Definition p1_in_0 : 'rV[T]_3 := (\o{F1} - \o{F0}) *m (can_tframe T) _R^ F0.
 
-Goal `[ p1_in_0 $ F0 ] = rmap F0 `[ \o{F1} - \o{F0} $ can_tframe T ].
+Goal '[ p1_in_0 $ F0 ] = rmap F0 '[ \o{F1} - \o{F0} $ can_tframe T ].
 Proof.
 rewrite /p1_in_0.
 by rewrite /rmap.
@@ -218,14 +218,14 @@ have H1 : From1To0 0 2%:R = 0.
   by rewrite !rowframeE.
 have [H2a H2b] : From1To0 0 0 ^+ 2 + From1To0 0 1 ^+ 2 = 1 /\
   From1To0 1 2%:R ^+ 2 + From1To0 2%:R 2%:R ^+ 2 = 1.
-  move: (norm_row_of_O (FromTo_is_O F1 F0) 0) => /= /(congr1 (fun x => x ^+ 2)).
+  move: (enorm_row_of_O (FromTo_is_O F1 F0) 0) => /= /(congr1 (fun x => x ^+ 2)).
   rewrite expr1n -dotmulvv dotmulE sum3E [_ 0 2%:R]mxE.
   move: (H1); rewrite {1}/From1To0 -lock => ->.
   rewrite  mulr0 addr0 -!expr2 => H1a.
   split.
     rewrite [_ 0 0]mxE [_ 0 1]mxE in H1a.
     by rewrite /From1To0 -lock.
-  move: (norm_col_of_O (FromTo_is_O F1 F0) 2%:R) => /= /(congr1 (fun x => x ^+ 2)).
+  move: (enorm_col_of_O (FromTo_is_O F1 F0) 2%:R) => /= /(congr1 (fun x => x ^+ 2)).
   rewrite expr1n -dotmulvv dotmulE sum3E 2![_ 0 0]mxE.
   move: (H1); rewrite {1}/From1To0 -lock => ->.
   by rewrite mulr0 add0r -!expr2 tr_col [_ 0 1]mxE [_ 0 2%:R]mxE /From1To0 -lock !mxE.
@@ -256,8 +256,8 @@ move: (H22);   rewrite {1}/From1To0 -lock => ->.
 rewrite 2![_ 0 2%:R]mxE => /eqP.
 rewrite addr_eq0 => /eqP H10_H20.
 
-move: (norm_col_of_O (FromTo_is_O F1 F0) 1) => /= /(congr1 (fun x => x ^+ 2)).
-rewrite expr1n sqr_norm sum3E tr_col [_ 0 0]mxE [_ 1 0]mxE.
+move: (enorm_col_of_O (FromTo_is_O F1 F0) 1) => /= /(congr1 (fun x => x ^+ 2)).
+rewrite expr1n sqr_enorm sum3E tr_col [_ 0 0]mxE [_ 1 0]mxE.
 move: (H01); rewrite {1}/From1To0 -lock => ->.
 rewrite [_ 0 1]mxE [_ 1 1]mxE [_ 0 2%:R]mxE [_ 1 2%:R]mxE.
 move/eqP. rewrite -addrA eq_sym addrC -subr_eq -cos2sin2. move/eqP.
@@ -266,8 +266,8 @@ rewrite mulrDr -(@exprMn _ _ (sin alpha) (_ 1 1)) (mulrC _ (_ 1 1)) H11_H21.
 rewrite sqrrN exprMn [in X in _ = X -> _](mulrC (sin alpha ^+ 2)).
 rewrite -mulrDr cos2Dsin2 mulr1 => /esym sqr_H21.
 
-move: (norm_col_of_O (FromTo_is_O F1 F0) 0) => /= /(congr1 (fun x => x ^+ 2)).
-rewrite sqr_norm sum3E 2![_ 0 0]mxE.
+move: (enorm_col_of_O (FromTo_is_O F1 F0) 0) => /= /(congr1 (fun x => x ^+ 2)).
+rewrite sqr_enorm sum3E 2![_ 0 0]mxE.
 move: (H00); rewrite {1}/From1To0 -lock => ->.
 rewrite expr1n [_ 0 1]mxE [_ 1 0]mxE [_ 0 2%:R]mxE [_ 2%:R 0]mxE.
 move=> H10_H20_save; move: (H10_H20_save).
@@ -296,8 +296,8 @@ have H4 : From1To0 = dh_rot theta alpha.
     move/eqP : (sa0) => /sin0cos1 /eqP.
     rewrite eqr_norml ler01 andbT.
 
-    move: (norm_row_of_O (FromTo_is_O F1 F0) 1) => /= /(congr1 (fun x => x ^+ 2)).
-    rewrite expr1n sqr_norm sum3E [_ 0 0]mxE [_ 0 1]mxE [_ 0 2%:R]mxE.
+    move: (enorm_row_of_O (FromTo_is_O F1 F0) 1) => /= /(congr1 (fun x => x ^+ 2)).
+    rewrite expr1n sqr_enorm sum3E [_ 0 0]mxE [_ 0 1]mxE [_ 0 2%:R]mxE.
     move: (H12); rewrite {1}/From1To0 -lock => ->; rewrite (eqP sa0) expr0n addr0.
     move=> H10_H11.
 
@@ -457,7 +457,7 @@ Variable T : rcfType.
 Let vector := 'rV[T]_3.
 Record t := mk {
   vaxis : vector ;
-  norm_vaxis : norm vaxis = 1 ;
+  norm_vaxis : `|vaxis|_e = 1 ;
   angle : T (* between to successive X axes *) }.
 End joint.
 End Joint.
@@ -530,7 +530,7 @@ Definition link_offset (frames : frame ^ n.+1) (links : link ^ n.+1) (i : 'I_n) 
   let: (o_succi, x_succi) := let f := frames succi in (\o{f}, f~i) in
   let: (o_i, x_i, z_i) := let f := frames i' in (\o{f}, f~i, f~k) in
   if intersection (zaxis (frames i')) (xaxis (frames succi)) is some o'_i then
-    (norm (o'_i - o_i)(*the Zi-coordiante of o'_i*) == Link.offset (links i')) &&
+    (`|o'_i - o_i|_e(*the Zi-coordiante of o'_i*) == Link.offset (links i')) &&
     (`| Link.offset (links i') | == distance_between_lines (xaxis (frames i')) (xaxis (frames succi)))
   else
     false (* should not happen since Zi always intersects Xi.+1 (see condidion 2.) *).

--- a/differential_kinematics.v
+++ b/differential_kinematics.v
@@ -59,7 +59,7 @@ Section about_bound_vectors.
 
 Variables (T : pzRingType) (F : tframe T).
 
-Definition FramedVect_of_Bound (p : bvec F) : fvec F := `[ BoundVect.endp p $ F ].
+Definition FramedVect_of_Bound (p : bvec F) : fvec F := '[ BoundVect.endp p $ F ].
 
 Definition BoundVect_add (a b : bvec F) : bvec F :=
   BoundVect.mk F (BoundVect.endp a + BoundVect.endp b).
@@ -74,7 +74,7 @@ Lemma BoundFramed_addA (a : bvec F) (b c : fvec F) :
 Proof. by rewrite /BoundFramed_add /= addrA. Qed.
 
 Definition BoundVect_sub (F : tframe T) (a b : bvec F) : fvec F :=
-  `[ BoundVect.endp a - BoundVect.endp b $ F ].
+  '[ BoundVect.endp a - BoundVect.endp b $ F ].
 
 Local Notation "a \-b b" := (BoundVect_sub a b).
 
@@ -159,7 +159,7 @@ Proof.
 move=> HF HG a b.
 have @G' : forall t0, rframe (F t0).
   move=> t0.
-  exact: (@RFrame.mk _ _ (@BoundVect.mk _ _ \o{F t0}) `[(F t0)~i $ F t0] `[(F t0)~j $ F t0] `[(F t0)~k $ F t0] (F t0)).
+  exact: (@RFrame.mk _ _ (@BoundVect.mk _ _ \o{F t0}) '[(F t0)~i $ F t0] '[(F t0)~j $ F t0] '[(F t0)~k $ F t0] (F t0)).
 apply: (@derivable_mx_FromTo' R F G' G).
 by [].
 by [].
@@ -462,7 +462,7 @@ Let o2 t : bvec F := RFrame.o (F2 t).
 
 Let r12 : forall t : R, bvec (F1 t) := fun t =>
   BoundVect.mk (F1 t)
-    (FramedVect.v (rmap (F1 t) `[ \o{F2 t} - \o{F1 t} $ F ])).
+    (FramedVect.v (rmap (F1 t) '[ \o{F2 t} - \o{F1 t} $ F ])).
 
 Hypothesis derivable_F1 : forall t, derivable_mx F1 t 1.
 Hypothesis derivable_F1o : forall t, derivable_mx (@TFrame.o R^o \o F1) t 1.
@@ -478,13 +478,13 @@ Qed.
 
 Definition w1 := ang_vel (fun t => (F1 t) _R^ F).
 
-Lemma eqn314_helper t : FramedVect.v (rmap F `[r12 t $ F1 t]) = \o{F2 t} - \o{F1 t}.
+Lemma eqn314_helper t : FramedVect.v (rmap F '[r12 t $ F1 t]) = \o{F2 t} - \o{F1 t}.
 Proof. by rewrite /= -mulmxA FromTo_comp FromToI mulmx1. Qed.
 
 (* lin. vel. of Link i as a function of
    the translational and rotational velocities of Link i-1 *)
 Lemma eqn314 t : derive1mx o2 t = derive1mx o1 t +
-  FramedVect.v (rmap F `[derive1mx r12 t $ F1 t])
+  FramedVect.v (rmap F '[derive1mx r12 t $ F1 t])
     (* velocity of the origin of Frame i w.r.t. the origin of Frame i-1 *) +
   w1 t *v (\o{F2 t} - \o{F1 t}).
 Proof.

--- a/euclidean.v
+++ b/euclidean.v
@@ -1,4 +1,4 @@
-(* coq-robot (c) 2017 AIST and INRIA. License: LGPL-2.1-or-later. *)
+(* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From HB Require Import structures.
 From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import sesquilinear.
@@ -7,8 +7,8 @@ From mathcomp Require Import realalg complex fingroup perm.
 From mathcomp Require Import reals.
 Require Import ssr_ext.
 
-(******************************************************************************)
-(*                     Elements of Euclidean geometry                         *)
+(**md**************************************************************************)
+(* # Elements of Euclidean geometry                                           *)
 (*                                                                            *)
 (* This file provides elements of Euclidean geometry, with specializations to *)
 (* the 3D case. It develops the theory of the dot-product and of the          *)
@@ -17,20 +17,25 @@ Require Import ssr_ext.
 (* preservation of the dot-product by orthogonal matrices or a closed formula *)
 (* for the characteristic polynomial of a 3x3 matrix.                         *)
 (*                                                                            *)
+(* ```                                                                        *)
 (*  jacobi_identity == Jacobi identity                                        *)
 (* lieAlgebraType R == the type of Lie algebra over R                         *)
 (*        lie[x, y] == Lie brackets                                           *)
+(* ```                                                                        *)
 (*                                                                            *)
+(* ```                                                                        *)
 (*        u *d w == the dot-product of the vectors u and v, i.e., the only    *)
 (*                  component of the 1x1-matrix u * v^T                       *)
-(*        norm u == the norm of vector u, i.e., the square root of u *d u     *)
+(*       enorm u == the norm of vector u, i.e., the square root of u *d u     *)
 (*   normalize u == scales vector u to be of unit norm                        *)
 (*       A _|_ B == A and B are normal                                        *)
 (*       'O[T]_n == the type of orthogonal matrices of size n                 *)
 (*      'SO[T]_n == the type of rotation matrices of size n                   *)
 (*       cross M == generalized cross-product                                 *)
+(* ```                                                                        *)
 (*                                                                            *)
 (* Specializations to the 3D case:                                            *)
+(* ```                                                                        *)
 (*      row2 a b == the row vector [a,b]                                      *)
 (*    row3 a b c == the row vector [a,b,c]                                    *)
 (*   col_mx2 u v == specialization of col_mx two row vectors of size 2        *)
@@ -41,6 +46,7 @@ Require Import ssr_ext.
 (*                  algebra                                                   *)
 (* vaxis_euler M == the vector-axis of the rotation matrix M of Euler's       *)
 (*                  theorem                                                   *)
+(* ```                                                                        *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -199,8 +205,8 @@ Section dotmul_bilinear_Pz.
 Variables (R : comPzRingType) (n : nat).
 
 Definition dotmul_rev (v u : 'rV[R]_n) := u *d v.
-Canonical rev_dotmul := @RevOp _ _ _ dotmul_rev (@dotmul R n)
-  (fun _ _ => erefl).
+(*Canonical rev_dotmul := @RevOp _ _ _ dotmul_rev (@dotmul R n)
+  (fun _ _ => erefl).*)
 
 Lemma dotmul_is_linear u : linear (dotmul u : 'rV[R]_n -> R^o).
 Proof. move=> /= k v w; by rewrite dotmulDr dotmulvZ. Qed.
@@ -252,50 +258,75 @@ move/allP => H; apply/eqP/rowP => i.
 apply/eqP; by rewrite mxE -sqrf_eq0 expr2 -(implyTb ( _ == _)) H.
 Qed.
 
-End dot_product.
-
-Section norm.
-
-Variables (T : rcfType) (n : nat).
-Implicit Types u v : 'rV[T]_n.
-
-Definition norm u := Num.sqrt (u *d u).
-
-Lemma normN u : norm (- u) = norm u.
-Proof. by rewrite /norm dotmulNv dotmulvN opprK. Qed.
-
-Lemma norm0 : norm 0 = 0.
-Proof. by rewrite /norm dotmul0v sqrtr0. Qed.
-
-Lemma norm_delta_mx i : norm 'e_i = 1.
-Proof. by rewrite /norm /dotmul trmx_delta mul_delta_mx mxE !eqxx sqrtr1. Qed.
-
-Lemma norm_ge0 u : norm u >= 0.
-Proof. by apply sqrtr_ge0. Qed.
-Hint Resolve norm_ge0 : core.
-
-Lemma normr_norm u : `|norm u| = norm u.
-Proof. by rewrite ger0_norm. Qed.
-
-Lemma norm_eq0 u : (norm u == 0) = (u == 0).
-Proof. by rewrite -sqrtr0 eqr_sqrt // ?dotmulvv0 // le0dotmul. Qed.
-
-Lemma norm_gt0 u : (0 < norm u) = (u != 0).
-Proof. by rewrite lt_neqAle norm_ge0 andbT eq_sym norm_eq0. Qed.
-
-Lemma normZ (k : T) u : norm (k *: u) = `|k| * norm u.
+Lemma dotmul_is_hermitian x y :
+  (@dotmul T n) x y = (-1) ^+ false * idfun ((@dotmul T n) y x).
 Proof.
-by rewrite /norm dotmulvZ dotmulZv mulrA sqrtrM -expr2 ?sqrtr_sqr // sqr_ge0.
+by rewrite /= expr0 mul1r dotmulC.
 Qed.
 
-Lemma dotmulvv u : u *d u = norm u ^+ 2.
+HB.instance Definition _ :=
+  @isHermitianSesquilinear.Build _ _ _ _ _ dotmul_is_hermitian.
+
+Check @dotmul _ _ : {symmetric 'rV[T]_n}.
+
+Let neq0_enorm_gt0 (u : 'rV[T]_n) : u != 0 -> 0 < dotmul u u.
 Proof.
-rewrite /norm [_ ^+ _]sqr_sqrtr // dotmulE sumr_ge0 //.
+move=> u0.
+by rewrite lt_neqAle eq_sym dotmulvv0 u0 le0dotmul.
+Qed.
+
+HB.instance Definition _ := isDotProduct.Build _ _ (@dotmul T n) neq0_enorm_gt0.
+
+End dot_product.
+
+Section euclidean_norm.
+Context {T : rcfType} {n : nat}.
+Implicit Types u v : 'rV[T]_n.
+
+Local Notation "''[' u , v ]" := (dotmul u v) : ring_scope.
+Local Notation "''[' u ]" := '[u, u]%R : ring_scope.
+
+Definition enorm u : T := Num.sqrt '[u].
+
+Local Notation "`| x |_e" := (enorm x).
+
+Lemma enormN u : `| - u |_e = enorm u.
+Proof.
+by rewrite /enorm (@hnormN T false idfun).
+Qed.
+
+Lemma enorm0 : `| 0 |_e = 0.
+Proof. by rewrite /enorm dotmul0v sqrtr0. Qed.
+
+Lemma enorm_delta_mx i : `| 'e_i |_e = 1.
+Proof. by rewrite /enorm /dotmul trmx_delta mul_delta_mx mxE !eqxx sqrtr1. Qed.
+
+Lemma enorm_ge0 u : `| u |_e >= 0.
+Proof. exact: sqrtr_ge0. Qed.
+Hint Resolve enorm_ge0 : core.
+
+Lemma normr_enorm u : `| `| u |_e | = `| u |_e.
+Proof. by rewrite ger0_norm. Qed.
+
+Lemma enorm_eq0 u : (`| u |_e == 0) = (u == 0).
+Proof. by rewrite -sqrtr0 eqr_sqrt // ?dotmulvv0 // le0dotmul. Qed.
+
+Lemma enorm_gt0 u : (0 < `| u |_e ) = (u != 0).
+Proof. by rewrite lt_neqAle enorm_ge0 andbT eq_sym enorm_eq0. Qed.
+
+Lemma enormZ (k : T) u : `| k *: u |_e = `| k | * `| u |_e.
+Proof.
+by rewrite /enorm dotmulvZ dotmulZv mulrA sqrtrM -expr2 ?sqrtr_sqr // sqr_ge0.
+Qed.
+
+Lemma dotmulvv u : u *d u = `| u |_e ^+ 2.
+Proof.
+rewrite /enorm [_ ^+ _]sqr_sqrtr // dotmulE sumr_ge0 //.
 by move=> i _; rewrite sqr_ge0.
 Qed.
 
 Lemma polarization_identity v u :
-  v *d u = 1 / 4%:R * (norm (v + u) ^+ 2 - norm (v - u) ^+ 2).
+  v *d u = 1 / 4%:R * (`|v + u|_e ^+ 2 - `|v - u|_e ^+ 2).
 Proof.
 apply: (@mulrI _ 4%:R); first exact: pnatf_unit.
 rewrite [in RHS]mulrA div1r divrr ?pnatf_unit // mul1r.
@@ -306,74 +337,75 @@ rewrite opprD (addrCA (u *d u)) subrr addr0.
 by rewrite opprD addrA subrr add0r dotmulvN -mulNrn opprK.
 Qed.
 
-Lemma sqr_norm u : norm u ^+ 2 = \sum_i u``_i ^+ 2.
-Proof. rewrite -dotmulvv dotmulE; apply/eq_bigr => /= i _; by rewrite expr2. Qed.
+Lemma sqr_enorm u : `| u |_e ^+ 2 = \sum_i u``_i ^+ 2.
+Proof. by rewrite -dotmulvv dotmulE; apply/eq_bigr => /= i _; rewrite expr2. Qed.
 
-Lemma mxtrace_tr_mul u : \tr (u^T *m u) = norm u ^+ 2.
+Lemma mxtrace_tr_mul u : \tr (u^T *m u) = `| u |_e ^+ 2.
 Proof.
-rewrite /mxtrace sqr_norm; apply/eq_bigr => /= i _; by rewrite mulmx_trE -expr2.
+by rewrite /mxtrace sqr_enorm; apply/eq_bigr => /= i _; rewrite mulmx_trE -expr2.
 Qed.
 
-Section norm1.
-
+Section enorm1.
 Variable u : 'rV[T]_n.
-Hypothesis u1 : norm u = 1.
+Hypothesis u1 : `| u |_e = 1.
 
 Lemma norm1_neq0 : u != 0.
-Proof. move: u1; rewrite -norm_eq0 => ->; exact: oner_neq0. Qed.
+Proof. move: u1; rewrite -enorm_eq0 => ->; exact: oner_neq0. Qed.
 
 Lemma dotmul1 : u *m u^T = 1.
 Proof. by rewrite dotmulP dotmulvv u1 expr1n. Qed.
 
-End norm1.
+End enorm1.
 
-End norm.
+End euclidean_norm.
+
+Notation "`| x |_e" := (enorm x).
 
 Section normalize.
-
 Variables (T : rcfType) (n : nat).
 Implicit Type u v : 'rV[T]_3.
 
-Definition normalize v := (norm v)^-1 *: v.
+Definition normalize v := (`| v |_e)^-1 *: v.
 
 Lemma normalize0 : normalize 0 = 0.
 Proof. by rewrite /normalize scaler0. Qed.
 
 Lemma normalizeN u : normalize (- u) = - normalize u.
-Proof. by rewrite /normalize normN scalerN. Qed.
+Proof. by rewrite /normalize enormN scalerN. Qed.
 
-Lemma normalizeI v : norm v = 1 -> normalize v = v.
+Lemma normalizeI v : `| v |_e = 1 -> normalize v = v.
 Proof. by move=> v1; rewrite /normalize v1 invr1 scale1r. Qed.
 
-Lemma norm_normalize v : v != 0 -> norm (normalize v) = 1.
+Lemma norm_normalize v : v != 0 -> `| normalize v |_e = 1.
 Proof.
-move=> v0; rewrite normZ ger0_norm; last by rewrite invr_ge0 // norm_ge0.
-by rewrite mulVr // unitfE norm_eq0.
+move=> v0; rewrite enormZ ger0_norm; last by rewrite invr_ge0// enorm_ge0.
+by rewrite mulVr// unitfE enorm_eq0.
 Qed.
 
 Lemma normalize_eq0 v : (normalize v == 0) = (v == 0).
 Proof.
 apply/idP/idP => [|/eqP ->]; last by rewrite normalize0.
 case/boolP : (v == 0) => [//| /norm_normalize].
-rewrite -norm_eq0 => -> /negPn; by rewrite oner_neq0.
+by rewrite -enorm_eq0 => -> /negPn; rewrite oner_neq0.
 Qed.
 
-Lemma norm_scale_normalize u : norm u *: normalize u = u.
+Lemma norm_scale_normalize u : `| u |_e *: normalize u = u.
 Proof.
-case/boolP : (u == 0) => [/eqP -> {u}|u0]; first by rewrite norm0 scale0r.
-by rewrite /normalize scalerA divrr ?scale1r // unitfE norm_eq0.
+have [->|u0] := eqVneq u 0; first by rewrite enorm0 scale0r.
+by rewrite /normalize scalerA divrr ?scale1r // unitfE enorm_eq0.
 Qed.
 
-Lemma normalizeZ u (u0 : u != 0) k (k0 : 0 < k) : normalize (k *: u) = normalize u.
+Lemma normalizeZ u (u0 : u != 0) k (k0 : 0 < k) :
+  normalize (k *: u) = normalize u.
 Proof.
-rewrite {1}/normalize normZ gtr0_norm // invrM ?unitfE ?gt_eqF // ?norm_gt0 //.
+rewrite {1}/normalize enormZ gtr0_norm // invrM ?unitfE ?gt_eqF ?enorm_gt0//.
 by rewrite scalerA -mulrA mulVr ?mulr1 ?unitfE ?gt_eqF.
 Qed.
 
 (* NB: not used *)
-Lemma dotmul_normalize_norm u : u *d normalize u = norm u.
+Lemma dotmul_normalize_enorm u : u *d normalize u = `| u |_e.
 Proof.
-case/boolP : (u == 0) => [/eqP ->{u}|u0]; first by rewrite norm0 dotmul0v.
+have [->|u0] := eqVneq u 0; first by rewrite enorm0 dotmul0v.
 rewrite -{1}(norm_scale_normalize u) dotmulZv dotmulvv norm_normalize //.
 by rewrite expr1n mulr1.
 Qed.
@@ -382,9 +414,9 @@ Lemma dotmul_normalize u v : (normalize u *d v == 0) = (u *d v == 0).
 Proof.
 case/boolP : (u == 0) => [/eqP ->|u0]; first by rewrite normalize0.
 apply/idP/idP.
-  rewrite /normalize dotmulZv mulf_eq0 => /orP [|//].
-  by rewrite invr_eq0 norm_eq0 (negbTE u0).
-rewrite /normalize dotmulZv => /eqP ->; by rewrite mulr0.
+  rewrite /normalize dotmulZv mulf_eq0 => /orP[|//].
+  by rewrite invr_eq0 enorm_eq0 (negbTE u0).
+by rewrite /normalize dotmulZv => /eqP ->; rewrite mulr0.
 Qed.
 
 End normalize.
@@ -657,23 +689,25 @@ rewrite -subr_eq0 -{1}(scale1r (v *m _)) -scalerBl scaler_eq0 => /orP [].
 by rewrite dotmul_conjc_eq0 (negbTE v0).
 Qed.
 
-Lemma norm_row_of_O (T : rcfType) n M : M \is 'O[T]_n.+1 -> forall i, norm (row i M) = 1.
+Lemma enorm_row_of_O (T : rcfType) n M : M \is 'O[T]_n.+1 ->
+  forall i, `|row i M|_e = 1.
 Proof.
 move=> MSO i.
-apply/eqP; rewrite -(@eqrXn2 _ 2) // ?norm_ge0 // expr1n; apply/eqP.
-rewrite -dotmulvv; move/orthogonalP : MSO => /(_ i i) ->; by rewrite eqxx.
+apply/eqP; rewrite -(@eqrXn2 _ 2) ?enorm_ge0// expr1n; apply/eqP.
+by rewrite -dotmulvv; move/orthogonalP : MSO => /(_ i i) ->; rewrite eqxx.
 Qed.
 
 Lemma dot_row_of_O (T : pzRingType) n M : M \is 'O[T]_n.+1 -> forall i j,
   row i M *d row j M = (i == j)%:R.
 Proof. by move/orthogonalP. Qed.
 
-Lemma norm_col_of_O (T : rcfType) n M : M \is 'O[T]_n.+1 -> forall i, norm (col i M)^T = 1.
+Lemma enorm_col_of_O (T : rcfType) n M : M \is 'O[T]_n.+1 ->
+  forall i, `| (col i M)^T |_e = 1.
 Proof.
 move=> MSO i.
 apply/eqP.
-rewrite -(@eqrXn2 _ 2) // ?norm_ge0 // expr1n -dotmulvv tr_col dotmulvv.
-by rewrite norm_row_of_O ?expr1n // orthogonalV.
+rewrite -(@eqrXn2 _ 2) ?enorm_ge0// expr1n -dotmulvv tr_col dotmulvv.
+by rewrite enorm_row_of_O ?expr1n// orthogonalV.
 Qed.
 
 Lemma orth_preserves_sqr_norm (T : comPzRingType) n M : M \is 'O[T]_n.+1 ->
@@ -703,23 +737,25 @@ by rewrite eqr_pMn2r // => /eqP.
 Qed.
 
 Lemma orth_preserves_norm (T : rcfType) n M : M \is 'O[T]_n.+1 ->
-  {mono (fun u => u *m M) : x / norm x }.
-Proof. move=> HM v; by rewrite /norm (proj2 (orth_preserves_dotmul M) HM). Qed.
+  {mono (fun u => u *m M) : x / `| x |_e }.
+Proof. move=> HM v; by rewrite /enorm (proj2 (orth_preserves_dotmul M) HM). Qed.
 
-Lemma Oij_ub (T : rcfType) n (M : 'M[T]_n.+1) : M \is 'O[T]_n.+1 -> forall i j, `| M i j | <= 1.
+Lemma Oij_ub (T : rcfType) n (M : 'M[T]_n.+1) : M \is 'O[T]_n.+1 ->
+  forall i j, `| M i j | <= 1.
 Proof.
-move=> /norm_row_of_O MO i j; rewrite leNgt; apply/negP => abs.
+move=> /enorm_row_of_O MO i j; rewrite leNgt; apply/negP => abs.
 move: (MO i) => /(congr1 (fun x => x ^+ 2)); apply/eqP.
-rewrite gt_eqF // sqr_norm (bigD1 j) //= !mxE -(addr0 (1 ^+ 2)) ltr_leD //.
+rewrite gt_eqF // sqr_enorm (bigD1 j) //= !mxE -(addr0 (1 ^+ 2)) ltr_leD //.
 by rewrite -(sqr_normr (M _ _)) ltrXn2r.
 rewrite sumr_ge0 // => k ij; by rewrite sqr_ge0.
 Qed.
 
-Lemma O_tr_idmx (T : rcfType) n (M : 'M[T]_n.+1) : M \is 'O[T]_n.+1 -> \tr M = n.+1%:R -> M = 1.
+Lemma O_tr_idmx (T : rcfType) n (M : 'M[T]_n.+1) : M \is 'O[T]_n.+1 ->
+  \tr M = n.+1%:R -> M = 1.
 Proof.
-move=> MO; move: (MO) => /norm_row_of_O MO' tr3.
-have Mdiag : forall i, M i i = 1.
-  move=> i; apply/eqP/negPn/negP => Mii; move: tr3; apply/eqP.
+move=> MO; move: (MO) => /enorm_row_of_O MO' tr3.
+have Mdiag i : M i i = 1.
+  apply/eqP/negPn/negP => Mii; move: tr3; apply/eqP.
   rewrite lt_eqF // /mxtrace.
   rewrite (bigD1 i) //=.
   rewrite (eq_bigr (fun i : 'I_n.+1 => M (inord i) (inord i))); last first.
@@ -734,7 +770,7 @@ have Mdiag : forall i, M i i = 1.
 apply/matrixP => i j; rewrite !mxE.
 case/boolP : (i == j) => [/eqP ->|ij]; first by move : Mdiag => /(_ j).
 move: (MO' i) => /(congr1 (fun x => x ^+ 2)).
-rewrite expr1n sqr_norm (bigD1 i) //= mxE.
+rewrite expr1n sqr_enorm (bigD1 i) //= mxE.
 move: Mdiag => /(_ i) -> /eqP.
 rewrite expr1n addrC eq_sym -subr_eq subrr eq_sym psumr_eq0 /=; last first.
   by move=> *; rewrite sqr_ge0.
@@ -904,8 +940,8 @@ Proof. by rewrite e2row row3Z mulr1 mulr0. Qed.
 
 End row3.
 
-Lemma norm_row3z (T : rcfType) (z : T) : norm (row3 0 0 z) = `|z|.
-Proof. by rewrite /norm dotmulE sum3E !mxE /= ?(mul0r,add0r) sqrtr_sqr. Qed.
+Lemma enorm_row3z (T : rcfType) (z : T) : `|row3 0 0 z|_e = `|z|.
+Proof. by rewrite /enorm dotmulE sum3E !mxE /= ?(mul0r,add0r) sqrtr_sqr. Qed.
 
 Section col_mx2.
 Variable (T : pzRingType).
@@ -1421,10 +1457,10 @@ Section norm3.
 Variable T : rcfType.
 Implicit Types u : 'rV[T]_3.
 
-Lemma norm_crossmul' u v :
-  (norm (u *v v)) ^+ 2 = (norm u * norm v) ^+ 2 - (u *d v) ^+ 2.
+Lemma enorm_crossmul' u v :
+  `| u *v v |_e ^+ 2 = (`| u |_e * `| v |_e) ^+ 2 - (u *d v) ^+ 2.
 Proof.
-rewrite sqr_norm sum3E crossmulE /SimplFunDelta /= !mxE /=.
+rewrite sqr_enorm sum3E crossmulE /SimplFunDelta /= !mxE /=.
 transitivity (((u``_0)^+2 + (u``_1)^+2 + (u``_2%:R)^+2)
   * ((v``_0)^+2 + (v``_1)^+2 + (v``_2%:R)^+2)
   - (u``_0 * v``_0 + u``_1 * v``_1 + u``_2%:R * v``_2%:R)^+2).
@@ -1487,40 +1523,41 @@ transitivity (((u``_0)^+2 + (u``_1)^+2 + (u``_2%:R)^+2)
   rewrite -!mulNrn !mulr2n !opprD.
   rewrite addrC -!addrA; congr (_ + _).
   by rewrite addrCA.
-rewrite exprMn -(sum3E (fun i => u``_i ^+ 2)) -(sum3E (fun i => v``_i ^+ 2)) -2!sqr_norm; congr (_ - _ ^+ 2).
+rewrite exprMn -(sum3E (fun i => u``_i ^+ 2)) -(sum3E (fun i => v``_i ^+ 2)) -2!sqr_enorm; congr (_ - _ ^+ 2).
 by rewrite dotmulE sum3E.
 Qed.
 
-Lemma orth_preserves_norm_crossmul M : M \is 'O[T]_3 ->
-  {mono (fun u => u *m M) : x y / norm (x *v y)}.
+Lemma orth_preserves_enorm_crossmul M : M \is 'O[T]_3 ->
+  {mono (fun u => u *m M) : x y / `| x *v y |_e}.
 Proof.
 move=> MO u v.
-by rewrite -[in RHS](orth_preserves_norm MO) mulmxr_crossmulr // normZ orthogonal_det // mul1r.
+by rewrite -[in RHS](orth_preserves_norm MO) mulmxr_crossmulr // enormZ orthogonal_det // mul1r.
 Qed.
 
-Lemma norm_crossmul_normal u v : u *d v = 0 ->
-  norm u = 1 -> norm v = 1 -> norm (u *v v) = 1.
+Lemma enorm_crossmul_normal u v : u *d v = 0 ->
+  `| u |_e = 1 -> `| v |_e = 1 -> `| u *v v |_e = 1.
 Proof.
 move=> uv0 u1 v1; apply/eqP.
-rewrite -(@eqrXn2 _ 2) // ?norm_ge0 //.
-by rewrite norm_crossmul' u1 v1 uv0 expr0n /= subr0 mulr1 // norm_ge0.
+rewrite -(@eqrXn2 _ 2) ?enorm_ge0//.
+by rewrite enorm_crossmul' u1 v1 uv0 expr0n /= subr0 mulr1 // norm_ge0.
 Qed.
 
-Lemma dotmul_eq0_crossmul_neq0 (u v : 'rV[T]_3) : u != 0 -> v != 0 -> u *d v == 0 -> u *v v != 0.
+Lemma dotmul_eq0_crossmul_neq0 (u v : 'rV[T]_3) : u != 0 -> v != 0 ->
+  u *d v == 0 -> u *v v != 0.
 Proof.
 move=> u0 v0 uv0.
-rewrite -norm_eq0 -(@eqrXn2 _ 2) // ?norm_ge0 // exprnP expr0n -exprnP.
-rewrite norm_crossmul' (eqP uv0) expr0n subr0 -expr0n eqrXn2 //.
-by rewrite mulf_eq0 negb_or 2!norm_eq0 u0.
-by rewrite mulr_ge0 // ?norm_ge0.
+rewrite -enorm_eq0 -(@eqrXn2 _ 2) ?enorm_ge0// exprnP expr0n -exprnP.
+rewrite enorm_crossmul' (eqP uv0) expr0n subr0 -expr0n eqrXn2 //.
+  by rewrite mulf_eq0 negb_or 2!enorm_eq0 u0.
+by rewrite mulr_ge0 ?enorm_ge0.
 Qed.
 
 End norm3.
 
 Section properties_of_canonical_vectors.
 
-Lemma normeE (T : rcfType) i : norm ('e_i : 'rV_3) = 1 :> T.
-Proof. by rewrite norm_delta_mx. Qed.
+Lemma enormeE (T : rcfType) i : `| 'e_i : 'rV_3 |_e = 1 :> T.
+Proof. by rewrite enorm_delta_mx. Qed.
 
 Variable T : comPzRingType.
 
@@ -1570,8 +1607,8 @@ End properties_of_canonical_vectors.
 
 Lemma orthogonal3P (T : rcfType) (M : 'M[T]_3) :
   reflect (M \is 'O[T]_3)
-  [&& norm (row 0 M) == 1, norm (row 1 M) == 1, norm (row 2%:R M) == 1,
-      row 0 M *d row 1 M == 0, row 0 M *d row 2%:R M == 0 & row 1 M *d row 2%:R M == 0].
+  [&& `|row 0 M|_e == 1, `|row 1 M|_e == 1, `|row 2 M|_e == 1,
+      row 0 M *d row 1 M == 0, row 0 M *d row 2 M == 0 & row 1 M *d row 2 M == 0].
 Proof.
 apply (iffP idP).
 - case/and6P => /eqP ni /eqP nj /eqP nk /eqP xy0 /eqP xz0 /eqP yz0 /=.
@@ -1583,20 +1620,20 @@ apply (iffP idP).
   + case/boolP : (j == 0) => [|/ifnot0P/orP[]]/eqP->; by
       [rewrite dotmulC xz0 | rewrite dotmulC yz0 | rewrite dotmulvv nk expr1n].
 - move/orthogonalP => H; apply/and6P; split; first [
-    by rewrite -(@eqrXn2 _ 2) // ?norm_ge0 // expr1n -dotmulvv H |
+    by rewrite -(@eqrXn2 _ 2) ?enorm_ge0// expr1n -dotmulvv H |
     by rewrite H ].
 Qed.
 
 Lemma rotation3P (T : rcfType) (M : 'M[T]_3) :
   reflect (M \is 'SO[T]_3)
-  [&& norm (row 0 M) == 1, norm (row 1 M) == 1,
-      row 0 M *d row 1 M == 0 & row 2%:R M == row 0 M *v row 1 M].
+  [&& `|row 0 M|_e == 1, `|row 1 M|_e == 1,
+      row 0 M *d row 1 M == 0 & row 2 M == row 0 M *v row 1 M].
 Proof.
 apply (iffP idP).
 - case/and4P => /eqP ni /eqP nj /eqP xy0 /eqP zxy0 /=.
   rewrite rotationE; apply/andP; split.
     apply/orthogonal3P.
-    rewrite ni nj /= zxy0 norm_crossmul_normal // xy0 !eqxx /= dot_crossmulC.
+    rewrite ni nj /= zxy0 enorm_crossmul_normal // xy0 !eqxx /= dot_crossmulC.
     by rewrite (@liexx _ (vec3 T)) dotmul0v dot_crossmulCA (@liexx _ (vec3 T)) dotmulv0 !eqxx.
   rewrite -(col_mx3_row M) -crossmul_triple zxy0 double_crossmul dotmulvv nj expr1n.
   by rewrite scale1r (dotmulC (row 1 M)) xy0 scale0r subr0 dotmulvv ni expr1n.
@@ -1606,18 +1643,18 @@ apply (iffP idP).
 Qed.
 
 Lemma SO_icrossj (T : rcfType) (r : 'M[T]_3) : r \is 'SO[T]_3 ->
-  row 0 r *v row 1 r = row 2%:R r.
+  row 0 r *v row 1 r = row 2 r.
 Proof. by case/rotation3P/and4P => _ _ _ /eqP ->. Qed.
 
 Lemma SO_icrossk (T : rcfType) (r : 'M[T]_3) : r \is 'SO[T]_3 ->
-  row 0 r *v row 2%:R r = - row 1 r.
+  row 0 r *v row 2 r = - row 1 r.
 Proof.
 case/rotation3P/and4P => /eqP H1 _ /eqP H3 /eqP ->.
 by rewrite double_crossmul H3 scale0r add0r dotmulvv H1 expr1n scale1r.
 Qed.
 
 Lemma SO_jcrossk (T : rcfType) (r : 'M[T]_3) : r \is 'SO[T]_3 ->
-  row 1 r *v row 2%:R r = row 0 r.
+  row 1 r *v row 2 r = row 0 r.
 Proof.
 case/rotation3P/and4P => _ /eqP H1 /eqP H3 /eqP ->.
 by rewrite double_crossmul dotmulvv H1 expr1n scale1r dotmulC H3 scale0r subr0.
@@ -1671,8 +1708,7 @@ rewrite [X in _ + _ + X](_ : _ = - M 0 2%:R * M 2%:R 0); last first.
   rewrite [in X in X * _]/=.
   rewrite coefD coefM sum2E subn0 coefC coefC mulr0 add0r.
   rewrite coefC mul0r add0r coefM sum2E subn0 subnn coefC [in X in X * _`_1]/=.
-  rewrite !coefD !coefX !coefN !coefC/=.
-  rewrite !mul0r !addr0/= subr0 mulr1.
+  rewrite coefD coefX coefN !coefC/= !(subr0,mul0r,mulr0,mulr1,addr0).
   by rewrite mulNr.
 rewrite /Z.
 apply/(@mulrI _ 2%:R); first exact: pnatf_unit.

--- a/extra_trigo.v
+++ b/extra_trigo.v
@@ -1,9 +1,9 @@
 From mathcomp Require Import all_ssreflect ssralg ssrnum.
-From mathcomp Require Import interval reals trigo.
+From mathcomp Require Import boolp interval reals trigo.
 Require Import ssr_ext.
 
-(******************************************************************************)
-(*    Extra material for trigo                                                *)
+(**md**************************************************************************)
+(* # Extra material for trigo                                                 *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -120,78 +120,6 @@ have : sin a == 0 by rewrite -norm_cos_eq1 caE normrN normr1.
 rewrite sin_eq0_Npipi //; case: eqP => /= [aE _|_ /eqP //].
 by move/eqP: caE; rewrite aE cos0 -eqr_oppLR eqrNxx oner_eq0.
 Qed.
-
-(* NB: PR to analysis in progress *)
-Lemma acos1 : acos (1 : R) = 0.
-Proof.
-have := @cosK R 0; rewrite cos0 => -> //.
-by rewrite in_itv //= lexx pi_ge0.
-Qed.
-
-Lemma acos0 : acos (0 : R) = pi / 2%:R.
-Proof.
-have := @cosK R (pi / 2%:R).
-rewrite cos_pihalf => -> //.
-rewrite in_itv //= divr_ge0 ?ler0n ?pi_ge0 //=.
-rewrite ler_pdivrMr ?ltr0n //.
-by rewrite mulr_natr mulr2n -lerBlDr subrr pi_ge0.
-Qed.
-
-Lemma acosN1 : acos (- 1) = (pi : R).
-Proof.
-have oneB : -1 <= (-1 : R) <= 1 by rewrite lexx ge0_cp ?(ler0n _ 1).
-apply: cos_inj; rewrite ?in_itv//= ?pi_ge0 ?lexx //.
-  by rewrite acos_ge0 // acos_lepi.
-by rewrite acosK ?in_itv//= cospi.
-Qed.
-
-Lemma acosN a : -1 <= a <= 1 -> acos (- a) = pi - acos a.
-Proof.
-move=> aB.
-have aBN : -1 <= - a <= 1 by rewrite lerNl opprK lerNl andbC.
-apply: cos_inj; first by rewrite in_itv/= acos_ge0 // acos_lepi.
-  rewrite in_itv/= subr_ge0 acos_lepi // -subr_le0 addrAC subrr sub0r.
-  by rewrite oppr_cp0 acos_ge0.
-by rewrite addrC cosDpi cosN !acosK.
-Qed.
-
-Lemma cosKN a : - pi <= a <= 0 -> acos (cos a) = - a.
-Proof.
-move=> Hs.
-rewrite -(cosN a) cosK // ?in_itv/=.
-by rewrite lerNr oppr0 lerNl andbC.
-Qed.
-
-Lemma atan0 : atan 0 = 0 :> R.
-Proof.
-apply: tan_inj; first 2 last.
-- by rewrite atanK tan0.
-- by rewrite in_itv/= atan_gtNpi2 atan_ltpi2.
-by rewrite in_itv/= oppr_cp0 divr_gt0 ?pi_gt0 // ltr0n.
-Qed.
-
-Lemma atan1 : atan 1 = pi / 4%:R :> R.
-Proof.
-apply: tan_inj; first 2 last.
-- by rewrite atanK tan_piquarter.
-- by rewrite in_itv/= atan_gtNpi2 atan_ltpi2.
-have v2_ge0 : 0 <= 2%:R :> R by rewrite ler0n.
-have v2_gt0 : 0 < 2%:R :> R by rewrite ltr0n.
-rewrite in_itv/= -mulNr (lt_trans _ (_ : 0 < _ )) /=; last 2 first.
-- by rewrite mulNr oppr_cp0 divr_gt0 // pi_gt0.
-- by rewrite divr_gt0 ?pi_gt0 // ltr0n.
-rewrite (natrM _ 2 2) invfM mulrA lter_pdivrMr // divfK ?natr_eq0 //.
-  by rewrite ltr_pdivrMr // mulr_natr mulr2n -subr_gte0 addrK ?pi_gt0.
-by case: ltgtP v2_gt0.
-Qed.
-
-Lemma atanN (x : R) : atan (- x) = - atan x.
-Proof.
-apply: tan_inj; first by rewrite in_itv/= atan_ltpi2 atan_gtNpi2.
-  by rewrite in_itv/= ltrNl opprK ltrNl andbC atan_ltpi2 atan_gtNpi2.
-by rewrite tanN !atanK.
-Qed.
-(* /NB: PR to analysis in progress *)
 
 Lemma sin_half_angle a : `| sin (a / 2%:R) | = Num.sqrt ((1 - cos a) / 2%:R).
 Proof.

--- a/frame.v
+++ b/frame.v
@@ -1,4 +1,4 @@
-(* coq-robot (c) 2017 AIST and INRIA. License: LGPL-2.1-or-later. *)
+(* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From HB Require Import structures.
 From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
@@ -57,9 +57,9 @@ Record t : Type := mk {
   i : 'rV[T]_3 ;
   j : 'rV[T]_3 ;
   k : 'rV[T]_3 ;
-  normi : norm i = 1 ;
-  normj : norm j = 1 ;
-  normk : norm k = 1 ;
+  normi : `|i|_e = 1 ;
+  normj : `|j|_e = 1 ;
+  normk : `|k|_e = 1 ;
   idotj : i *d j = 0 ;
   jdotk : j *d k = 0 ;
   idotk : i *d k = 0
@@ -102,8 +102,8 @@ Let vector := 'rV[T]_3.
 Implicit Types p : 'rV[T]_3.
 Variable f : noframe T.
 
-Lemma noframe_norm (k : 'I_3) : norm f|,k = 1.
-Proof. by rewrite rowframeE; apply norm_row_of_O; case: f. Qed.
+Lemma noframe_norm (k : 'I_3) : `| f|,k |_e = 1.
+Proof. by rewrite rowframeE; apply enorm_row_of_O; case: f. Qed.
 
 Lemma noframe_idotj : f~i *d f~j = 0.
 Proof. by rewrite !rowframeE; apply/orthogonalP; case: f. Qed.
@@ -124,9 +124,9 @@ Proof. apply/orthogonal_unit. by case: f. Qed.
 Lemma noframe_inv : (matrix_of_noframe f)^-1 = f^T.
 Proof. rewrite -orthogonal_inv //; by case: f. Qed.
 
-Lemma norm_icrossj : norm (f~i *v f~j) = 1.
+Lemma norm_icrossj : `|f~i *v f~j|_e = 1.
 Proof.
-by rewrite norm_crossmul_normal // ?idotj // ?normi // normj.
+by rewrite enorm_crossmul_normal // ?idotj // ?normi // normj.
 Qed.
 
 Definition noframe_sgn := \det f.
@@ -447,7 +447,7 @@ Qed.
 Module Base1.
 Section base1.
 Variables (T : realType) (i : 'rV[T]_3).
-Hypothesis normi : norm i = 1.
+Hypothesis normi : `|i|_e = 1.
 
 Definition j := if colinear i 'e_0 then 'e_1 else normalize (normalcomp 'e_0 i).
 
@@ -458,7 +458,7 @@ Proof.
 rewrite /j; case: ifPn => [|_]; last first.
   by rewrite dotmulvZ -{3}(normalizeI normi) dotmul_orthogonalize mulr0.
 case/colinearP => [| [_ [k ->]]].
-  by rewrite -norm_eq0 norm_delta_mx (negbTE (oner_neq0 _)).
+  by rewrite -enorm_eq0 enorm_delta_mx (negbTE (oner_neq0 _)).
 by rewrite dotmulZv dote2 mulr0.
 Qed.
 
@@ -468,16 +468,16 @@ Proof. by rewrite /k dot_crossmulC (@liexx _ (vec3 T)) dotmul0v. Qed.
 Lemma jdotk : j *d k = 0.
 Proof. by rewrite /k dot_crossmulCA (@liexx _ (vec3 T)) dotmulv0. Qed.
 
-Lemma normj : norm j = 1.
+Lemma normj : `| j |_e = 1.
 Proof.
-rewrite /j; case: ifPn => iVi; first by rewrite norm_delta_mx.
+rewrite /j; case: ifPn => iVi; first by rewrite enorm_delta_mx.
 rewrite norm_normalize //; apply: contra iVi.
-by rewrite normalcomp_colinear // ?norm1_neq0 // colinear_sym.
+by rewrite normalcomp_colinear ?norm1_neq0// colinear_sym.
 Qed.
 
-Lemma normk : norm k = 1.
+Lemma normk : `| k |_e = 1.
 Proof.
-by rewrite /k norm_crossmul_normal // ?norm_normalize// ?normj// idotj // mulr0.
+by rewrite /k enorm_crossmul_normal // ?norm_normalize// ?normj// idotj // mulr0.
 Qed.
 
 Definition M := col_mx3 i j k.
@@ -522,7 +522,7 @@ Qed.
 End base1_lemmas.
 End Base1.
 
-Canonical base1_is_noframe (T : realType) (u : 'rV[T]_3) (u1 : norm u = 1) :=
+Canonical base1_is_noframe (T : realType) (u : 'rV[T]_3) (u1 : `|u|_e = 1) :=
   NOFrameInterface.mk u1 (Base1.normj u1) (Base1.normk u1)
   (Base1.idotj u1) (Base1.jdotk u) (Base1.idotk u).
 
@@ -536,9 +536,9 @@ Definition i := if u == 0 then 'e_0 else normalize u.
 Definition j := if u == 0 then 'e_1 else Base1.j i.
 Definition k := if u == 0 then 'e_2%:R else Base1.k i.
 
-Lemma normi : norm i = 1.
+Lemma normi : `| i |_e = 1.
 Proof.
-rewrite /i; case: ifP => [_|/eqP/eqP ?]; by rewrite ?normeE // norm_normalize.
+rewrite /i; case: ifP => [_|/eqP/eqP ?]; by rewrite ?enormeE// norm_normalize.
 Qed.
 
 Parameter frame : 'rV[T]_3 -> frame T.
@@ -560,10 +560,10 @@ Qed.
 Lemma frame0E (u0 : u != 0) : (frame u)~i = normalize u.
 Proof. by rewrite -iE /i (negbTE u0). Qed.
 
-Lemma normj : norm j = 1.
-Proof. by rewrite jE rowframeE norm_row_of_O // NOFrame.MO. Qed.
-Lemma normk : norm k = 1.
-Proof. by rewrite kE rowframeE norm_row_of_O // NOFrame.MO. Qed.
+Lemma normj : `| j |_e = 1.
+Proof. by rewrite jE rowframeE enorm_row_of_O // NOFrame.MO. Qed.
+Lemma normk : `| k |_e = 1.
+Proof. by rewrite kE rowframeE enorm_row_of_O // NOFrame.MO. Qed.
 
 Lemma idotj : i *d j = 0.
 Proof. by rewrite iE jE !rowframeE dot_row_of_O // NOFrame.MO. Qed.
@@ -689,7 +689,7 @@ Qed.
 End scalar_neg.
 End scalar.
 
-Lemma j_tr_mul (v : 'rV[T]_3) (v1 : norm v = 1) : j v *m v^T = 0.
+Lemma j_tr_mul (v : 'rV[T]_3) (v1 : `| v |_e = 1) : j v *m v^T = 0.
 Proof.
 rewrite /j (negbTE (norm1_neq0 v1)) /Base1.j.
 case: ifPn => [|_].
@@ -703,7 +703,7 @@ rewrite -scalemxAl scaler_eq0 {2}/i (negbTE (norm1_neq0 v1)) normalizeI //.
 by rewrite normalcomp_mul_tr // orbT.
 Qed.
 
-Lemma k_tr_mul (v : 'rV[T]_3) (v1 : norm v = 1) : k v *m v^T *m v = 0.
+Lemma k_tr_mul (v : 'rV[T]_3) (v1 : `| v |_e = 1) : k v *m v^T *m v = 0.
 Proof.
 rewrite /k (negbTE (norm1_neq0 v1)) /Base1.k /Base1.j.
 case: ifPn => [|_].
@@ -832,12 +832,12 @@ Qed.
 End FromTo_properties.
 
 (* TODO: move? *)
-Lemma sqr_norm_frame (T : realType) (a : frame T) (v : 'rV[T]_3) :
-  norm v ^+ 2 = \sum_(i < 3) (v *d (a |, i%:R))^+2.
+Lemma sqr_enorm_frame (T : realType) (a : frame T) (v : 'rV[T]_3) :
+  `| v |_e ^+ 2 = \sum_(i < 3) (v *d (a |, i%:R))^+2.
 Proof.
-have H : norm v = norm (v *m (can_frame T) _R^ a).
+have H : `| v |_e = `| v *m (can_frame T) _R^ a |_e.
   by rewrite orth_preserves_norm // FromTo_is_O.
-rewrite H sqr_norm [in LHS]sum3E [in RHS]sum3E; congr (_ ^+ 2 + _ ^+ 2 + _ ^+ 2);
+rewrite H sqr_enorm [in LHS]sum3E [in RHS]sum3E; congr (_ ^+ 2 + _ ^+ 2 + _ ^+ 2);
   by rewrite FromTo_from_can mxE_dotmul_row_col -tr_row trmxK row_id NOFrame.rowframeE.
 Qed.
 
@@ -855,27 +855,29 @@ End framed_vector.
 End FramedVect.
 Notation fvec := FramedVect.t.
 
-Notation "`[ v $ F ]" := (FramedVect.mk F v)
-  (at level 5, v, F at next level, format "`[ v  $  F ]").
+Notation "''[' v $ F ]" := (FramedVect.mk F v)
+  (at level 5, v, F at next level, format "''[' v  $  F ]") : frame_scope.
 
 Definition FramedVect_add (T : pzRingType) (F : tframe T) (a b : fvec F) : fvec F :=
-  `[ FramedVect.v a + FramedVect.v b $ F ].
+  '[ FramedVect.v a + FramedVect.v b $ F ].
 
 Notation "a \+f b" := (FramedVect_add a b) (at level 39).
 
-Lemma fv_eq (T : pzRingType) a b : a = b -> forall F : frame T, `[ a $ F ] = `[ b $ F ].
+Lemma fv_eq (T : pzRingType) a b : a = b -> forall F : frame T, '[ a $ F ] = '[ b $ F ].
 Proof. by move=> ->. Qed.
+
+Notation "a \+f b" := (FramedVect_add a b) (at level 39).
 
 Section change_of_coordinate_by_rotation.
 
 Variable T : realType.
 Implicit Types A B : frame T.
 
-Lemma FramedVectvK A (x : fvec A) : `[FramedVect.v x $ A] = x.
+Lemma FramedVectvK A (x : fvec A) : '[FramedVect.v x $ A] = x.
 Proof. by case: x. Qed.
 
 (* change of coordinates: "rotation mapping" from frame A to frame B *)
-Definition rmap A B (x : fvec A) : fvec B := `[FramedVect.v x *m (A _R^ B) $ B].
+Definition rmap A B (x : fvec A) : fvec B := '[FramedVect.v x *m (A _R^ B) $ B].
 
 Lemma rmapK A B (x : fvec A) : rmap A (rmap B x) = x.
 Proof.
@@ -885,15 +887,15 @@ by rewrite divrr ?noframe_is_unit // mulmx1 /= FramedVectvK.
 Qed.
 
 Lemma rmapE A B (x : 'rV[T]_3) :
-  rmap B `[x $ A] = `[x *m A (*A->can*) *m B^T(*can->B*) $ B].
+  rmap B '[x $ A] = '[x *m A (*A->can*) *m B^T(*can->B*) $ B].
 Proof. by rewrite /rmap FromToE noframe_inv mulmxA. Qed.
 
 Lemma rmapE_from_can A (x : 'rV[T]_3) :
-  rmap A `[x $ can_tframe T] = `[x *m A^T $ A].
+  rmap A '[x $ can_tframe T] = '[x *m A^T $ A].
 Proof. by rewrite rmapE can_frame_1 mulmx1. Qed.
 
 Lemma rmapE_to_can A (x : 'rV[T]_3) :
-  rmap (can_tframe T) `[x $ A] = `[x *m A $ can_tframe T].
+  rmap (can_tframe T) '[x $ A] = '[x *m A $ can_tframe T].
 Proof. by rewrite rmapE can_frame_1 trmx1 mulmx1. Qed.
 
 End change_of_coordinate_by_rotation.
@@ -961,22 +963,22 @@ Definition t := (i, j, k).
 Let ac : a != c.
 Proof. by apply: contra abc => /eqP ->; rewrite subrr /colinear linear0r. Qed.
 
-Lemma normi : norm i = 1.
+Lemma normi : `| i |_e = 1.
 Proof. by rewrite /i norm_normalize // subr_eq0 eq_sym. Qed.
 
 Lemma i_neq0 : i != 0.
-Proof. by rewrite -norm_eq0 normi oner_neq0. Qed.
+Proof. by rewrite -enorm_eq0 normi oner_neq0. Qed.
 
-Lemma normj : norm j = 1.
+Lemma normj : `| j |_e = 1.
 Proof.
 rewrite /j norm_normalize // normalcomp_colinear; last first.
-  by rewrite -norm_eq0 normi oner_neq0.
-apply: contra (abc); rewrite colinearvZ invr_eq0 norm_eq0 subr_eq0.
+  by rewrite -enorm_eq0 normi oner_neq0.
+apply: contra (abc); rewrite colinearvZ invr_eq0 enorm_eq0 subr_eq0.
 by rewrite eq_sym (negPf ab) /= colinear_sym.
 Qed.
 
 Lemma j_neq0 : j != 0.
-Proof. by rewrite -norm_eq0 normj oner_neq0. Qed.
+Proof. by rewrite -enorm_eq0 normj oner_neq0. Qed.
 
 Lemma idotj : i *d j = 0.
 Proof. by rewrite /= /i /j dotmulZv dotmulvZ dotmul_orthogonalize 2!mulr0. Qed.
@@ -987,11 +989,11 @@ Proof. by rewrite /k dot_crossmulCA (@liexx _ (vec3 T)) dotmulv0. Qed.
 Lemma idotk : i *d k = 0.
 Proof. by rewrite /k dot_crossmulC (@liexx _ (vec3 T)) dotmul0v. Qed.
 
-Lemma normk : norm k = 1.
-Proof. by rewrite norm_crossmul_normal // ?normi // ?normj // idotj. Qed.
+Lemma normk : `| k |_e = 1.
+Proof. by rewrite enorm_crossmul_normal // ?normi // ?normj // idotj. Qed.
 
 Lemma k_neq0 : k != 0.
-Proof. by rewrite -norm_eq0 normk oner_neq0. Qed.
+Proof. by rewrite -enorm_eq0 normk oner_neq0. Qed.
 
 Lemma is_O : col_mx3 i j k \is 'O[T]_3.
 Proof.

--- a/octonion.v
+++ b/octonion.v
@@ -1,4 +1,4 @@
-(* coq-robot (c) 2017 AIST and INRIA. License: LGPL-2.1-or-later. *)
+(* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From HB Require Import structures.
 From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
@@ -862,8 +862,8 @@ apply/eqP; rewrite eq_oct; apply/andP; split; apply/eqP.
   rewrite [in LHS]/= scaleoctE /=.
   rewrite !{1}(linear0, mul0r, mulr0, sub0r, add0r, subr0).
   rewrite [a.1 + _^*q]addrC addrK -scalerA addr0 -conjqE !mulrA !conjq_comm.
-  rewrite !conjqP /sqrq /= norm0 !expr0n  expr1n /= !add0r !addr0.
-  rewrite !normeE !mul1r expr1n mul1r -3!opprD addrA -!mulr2n scalerN.
+  rewrite !conjqP /sqrq /= enorm0 !expr0n expr1n /= !add0r !addr0.
+  rewrite !enormeE !mul1r expr1n mul1r -3!opprD addrA -!mulr2n scalerN.
   rewrite -mulrnA -scaler_nat !scalerA -scalerBl.
   rewrite -{1}[3%:R^-1]mulr1 -mulrA -mulrBr natrM mulrA mulNr.
   rewrite  mulVf ?(eqr_nat _ _ 0) //.
@@ -874,7 +874,7 @@ apply: etrans (_ : -(2%:R / 3%:R) *: a.2 + -(1 / 3%:R) *: a.2 = _).
   rewrite -scalerDl -opprD -mulrDl -(natrD _ _ 1) mulfV ?scaleN1r //.
   by rewrite (eqr_nat _ _ 0).
 congr (_ + _).
-  rewrite 3!addr0 -scalerA -!{1}mulrA !{1}conjqP /sqrq !normeE /=
+  rewrite 3!addr0 -scalerA -!{1}mulrA !{1}conjqP /sqrq !enormeE /=
           !expr0n !expr1n /=.
   rewrite !add0r !mul1r !mulr1 mulrC -mulrN -scalerA.
   rewrite -addrA -!mulr2n -mulrnA -scaler_nat !scalerA natrM mulrA.

--- a/quaternion.v
+++ b/quaternion.v
@@ -1,4 +1,4 @@
-(* coq-robot (c) 2025 AIST and INRIA. License: LGPL-2.1-or-later. *)
+(* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From HB Require Import structures.
 From mathcomp Require Import all_boot order ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
@@ -9,14 +9,15 @@ From mathcomp Require Import interval reals trigo.
 Require Import ssr_ext euclidean vec_angle frame rot.
 Require Import extra_trigo.
 
-(******************************************************************************)
-(*                            Quaternions                                     *)
+(**md**************************************************************************)
+(* # Quaternions                                                              *)
 (*                                                                            *)
 (* This file develops the theory of quaternions. It defines the type of       *)
 (* quaternions and the type of unit quaternions and show that quaternions     *)
 (* form a ZmodType, a RingType, a LmodType, a UnitRingType. It also defines   *)
 (* polar coordinates and dual quaternions.                                    *)
 (*                                                                            *)
+(* ```                                                                        *)
 (*        quat R == type of quaternions over the ringType R                   *)
 (*          x%:q == quaternion with scalar part x and vector part 0           *)
 (*   x \is realq == the quaternion x has no vector part                       *)
@@ -30,28 +31,36 @@ Require Import extra_trigo.
 (*       normq x == norm of the quaternion x                                  *)
 (*       uquat R == type of unit quaternions, i.e., quaternions with norm 1   *)
 (* conjugation x == v |-> x v x^*                                             *)
+(* ```                                                                        *)
 (*                                                                            *)
 (* Polar coordinates:                                                         *)
+(* ```                                                                        *)
 (*     polar_of_quat a == polar coordinates of the quaternion a               *)
 (*   quat_of_polar a u == quaternion corresponding to the polar coordinates   *)
 (*                        angle a and vector u                                *)
 (*          quat_rot x == snd \o conjugation x (rotation of angle 2a about    *)
 (*                        vector v where a,v are the polar coordinates of x,  *)
 (*                        a unit quaternion                                   *)
+(* ```                                                                        *)
+(*                                                                            *)
 (* Dual numbers:                                                              *)
+(* ```                                                                        *)
 (*     dual R == the type of dual numbers over a ringType R                   *)
 (*        x.1 == left part of the dual number x                               *)
 (*        x.2 == right part of the dual number x                              *)
+(* ```                                                                        *)
 (* Dual numbers are equipped with a structure of ZmodType, RingType, and of   *)
 (* LmodType when R is a ringType, of Com/UnitRingType when R is a             *)
 (* Com/UnitRingType.                                                          *)
 (*                                                                            *)
 (* Dual quaternions:                                                          *)
+(* ```                                                                        *)
 (*     x +ɛ* y  == dual number formed by x and y                              *)
 (*        dquat == type of dual quaternions                                   *)
 (* x \is puredq == the dual quaternion x is pure                              *)
 (*   a \is dnum == a has no vector part                                       *)
 (*        x^*dq == conjugate of dual quaternion x                             *)
+(* ```                                                                        *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -471,23 +480,23 @@ Section quaternion1.
 Variable R : realType.
 Implicit Types x y : quat R.
 
-Definition sqrq x := x.1 ^+ 2 + norm (x.2) ^+ 2.
+Definition sqrq x := x.1 ^+ 2 + `|x.2|_e ^+ 2.
 
-Lemma sqrq0 : sqrq 0 = 0. Proof. by rewrite /sqrq norm0 expr0n add0r. Qed.
+Lemma sqrq0 : sqrq 0 = 0. Proof. by rewrite /sqrq enorm0 expr0n add0r. Qed.
 
 Lemma sqrq_ge0 x : 0 <= sqrq x. Proof. by rewrite addr_ge0 // sqr_ge0. Qed.
 
 Lemma sqrq_eq0 x : (sqrq x == 0) = (x == 0).
 Proof.
-rewrite /sqrq paddr_eq0 ?sqr_ge0// !sqrf_eq0 norm_eq0 -xpair_eqE.
+rewrite /sqrq paddr_eq0 ?sqr_ge0// !sqrf_eq0 enorm_eq0 -xpair_eqE.
 by rewrite -surjective_pairing.
 Qed.
 
 Lemma sqrqN x : sqrq (- x) = sqrq x.
-Proof. by rewrite /sqrq /= normN sqrrN. Qed.
+Proof. by rewrite /sqrq /= enormN sqrrN. Qed.
 
 Lemma sqrq_conj x : sqrq (x ^*q) = sqrq x.
-Proof. by rewrite /sqrq normN. Qed.
+Proof. by rewrite /sqrq enormN. Qed.
 
 Lemma conjqP x : x * x^*q = (sqrq x)%:q.
 Proof.
@@ -515,11 +524,11 @@ Proof.
 apply/eqP; rewrite eq_quat; apply/andP; split; apply/eqP.
   rewrite [in LHS]/= scaleqE /=.
   rewrite !(mul0r,mulr0,addr0) scale0r !add0r !dotmulDl.
-  rewrite dotmulZv dotmulvv normeE expr1n mulr1 dotmulC
+  rewrite dotmulZv dotmulvv enormeE expr1n mulr1 dotmulC
           dot_crossmulC (@liexx _ (vec3 R)) dotmul0v addr0.
-  rewrite subrr add0r dotmulZv dotmulvv normeE expr1n mulr1
+  rewrite subrr add0r dotmulZv dotmulvv enormeE expr1n mulr1
           dotmulC dot_crossmulC (@liexx _ (vec3 R)) .
-  rewrite dotmul0v addr0 dotmulZv dotmulvv normeE expr1n mulr1
+  rewrite dotmul0v addr0 dotmulZv dotmulvv enormeE expr1n mulr1
           opprD addrA dotmulC dot_crossmulC.
   rewrite (@liexx _ (vec3 R))  dotmul0v subr0 -opprD mulrN mulNr
           opprK -mulr2n -(mulr_natl x.1) mulrA.
@@ -527,13 +536,13 @@ apply/eqP; rewrite eq_quat; apply/andP; split; apply/eqP.
 rewrite /= !(mul0r,scale0r,add0r,addr0).
 rewrite [_ *v 'e_0](@lieC _ (vec3 R)) /= ['e_0 *v _]linearD /=.
 rewrite ['e_0 *v (x.1 *: _)]linearZ /= (@liexx _ (vec3 R)) .
-rewrite scaler0 add0r double_crossmul dotmulvv normeE expr1n scale1r.
+rewrite scaler0 add0r double_crossmul dotmulvv enormeE expr1n scale1r.
 rewrite [_ *v 'e_1](@lieC _ (vec3 R)) /= ['e_1 *v _]linearD /=.
 rewrite ['e_1 *v (x.1 *: _)]linearZ /= (@liexx _ (vec3 R)) .
-rewrite scaler0 add0r double_crossmul dotmulvv normeE expr1n scale1r.
+rewrite scaler0 add0r double_crossmul dotmulvv enormeE expr1n scale1r.
 rewrite [_ *v 'e_2%:R](@lieC _ (vec3 R)) /= ['e_2%:R *v _]linearD /=.
 rewrite ['e_2%:R *v (x.1 *: _)]linearZ /= (@liexx _ (vec3 R)).
-rewrite scaler0 add0r double_crossmul dotmulvv normeE expr1n scale1r.
+rewrite scaler0 add0r double_crossmul dotmulvv enormeE expr1n scale1r.
 rewrite [X in _ = - _ *: X](_ : _ = 2%:R *:x.2).
   by rewrite scalerA mulNr div1r mulVr ?unitfE ?pnatr_eq0 // scaleN1r.
 rewrite !opprB (addrCA _ x.2).
@@ -617,10 +626,10 @@ Lemma invqE x : x^-1 = invq x. Proof. by done. Qed.
 Definition normq x := Num.sqrt (sqrq x).
 
 Lemma normq0 : normq 0 = 0.
-Proof. by rewrite /normq /sqrq expr0n /= norm0 add0r expr0n sqrtr0. Qed.
+Proof. by rewrite /normq /sqrq expr0n /= enorm0 add0r expr0n sqrtr0. Qed.
 
 Lemma normqc x : normq x^*q = normq x.
-Proof. by rewrite /normq /sqrq /= normN. Qed.
+Proof. by rewrite /normq /sqrq /= enormN. Qed.
 
 Lemma normqE x : (normq x ^+ 2)%:q = x^*q * x.
 Proof.
@@ -634,9 +643,9 @@ Proof. by apply sqrtr_ge0. Qed.
 Lemma normq_eq0 x : (normq x == 0) = (x == 0).
 Proof. by rewrite /normq -{1}sqrtr0 eqr_sqrt ?sqrq_ge0// sqrq_eq0. Qed.
 
-Lemma normq_vector (u : 'rV[R]_3) : normq u%:v = norm u.
+Lemma normq_vector (u : 'rV[R]_3) : normq u%:v = `|u|_e.
 Proof.
-by rewrite /normq /sqrq /= expr0n add0r sqrtr_sqr ger0_norm ?norm_ge0.
+by rewrite /normq /sqrq /= expr0n add0r sqrtr_sqr ger0_norm ?enorm_ge0.
 Qed.
 
 Lemma normqM x y : normq (x * y) = normq x * normq y.
@@ -650,7 +659,7 @@ Qed.
 
 Lemma normqZ (k : R) x : normq (k *: x) = `|k| * normq x.
 Proof.
-by rewrite /normq /sqrq /= normZ 2!exprMn sqr_normr -mulrDr sqrtrM ?sqr_ge0 //
+by rewrite /normq /sqrq /= enormZ 2!exprMn sqr_normr -mulrDr sqrtrM ?sqr_ge0 //
            sqrtr_sqr.
 Qed.
 
@@ -679,7 +688,7 @@ Definition lequat x y := (x.2 == y.2) && (x.1 <= y.1).
 
 Lemma lequat_normD x y : lequat (normQ (x + y)) (normQ x + normQ y).
 Proof.
-rewrite /lequat /= add0r eqxx andTb /normq /sqrq !sqr_norm !sum3E /= !mxE.
+rewrite /lequat /= add0r eqxx andTb /normq /sqrq !sqr_enorm !sum3E /= !mxE.
 pose X := nth 0 [:: x.1; x _i; x _j; x _k].
 pose Y := nth 0 [:: y.1; y _i; y _j; y _k].
 suff: Num.sqrt (\sum_(i < 4) (X i + Y i)^+2) <=
@@ -769,12 +778,12 @@ apply/idP/idP.
   rewrite /lequat /=.
   case/andP => /eqP<- x0Ly0.
   apply/eqP; congr mkQuat; rewrite ?subrr ?expr0n ?addr0 //=.
-  rewrite norm0 expr0n addr0 sqrtr_sqr.
+  rewrite enorm0 expr0n addr0 sqrtr_sqr.
   by apply/eqP; rewrite -ger0_def subr_ge0.
 case/eqP => /eqP H H1.
 move: (sym_equal H1) H => /subr0_eq->.
 rewrite /lequat /= eqxx /=.
-by rewrite subrr norm0 expr0n addr0 sqrtr_sqr -ger0_def subr_ge0.
+by rewrite subrr enorm0 expr0n addr0 sqrtr_sqr -ger0_def subr_ge0.
 Qed.
 
 Lemma ltquat_def x y : ltquat x y = (y != x) && lequat x y.
@@ -815,7 +824,7 @@ Lemma invuq_proof x : x \is uquat -> normq (x^-1) == 1.
 Proof. by move=> ux; rewrite invq_uquat // normqc. Qed.
 
 Lemma cos_atan_uquat x : x \is uquat -> x \isn't pureq ->
-  let a := atan (norm x.2 / x.1) in cos a ^+ 2 = x.1 ^+ 2.
+  let a := atan (`|x.2|_e / x.1) in cos a ^+ 2 = x.1 ^+ 2.
 Proof.
 move=> ux q00 a.
 rewrite cos_atan exprMn [x.1 ^-1 ^+2]exprVn.
@@ -826,7 +835,7 @@ by rewrite -exprVn sqrtr_sqr normfV invrK sqr_normr.
 Qed.
 
 Lemma sin_atan_uquat x : x \is uquat -> x \isn't pureq ->
-  let a := atan (norm x.2 / x.1) in sin a ^+ 2 = norm x.2 ^+ 2.
+  let a := atan (`|x.2|_e / x.1) in sin a ^+ 2 = `|x.2|_e ^+ 2.
 Proof.
 move=> ux q00 a.
 rewrite /a sqr_sin_atan.
@@ -852,7 +861,7 @@ by have := pureq_conj u%:v; rewrite qualifE /= eqxx => /esym/eqP ->; Simp.r.
 Qed.
 
 Lemma conjugationE x u : conjugation x u =
-  ((x.1 ^+ 2 - norm x.2 ^+ 2) *: u +
+  ((x.1 ^+ 2 - `|x.2|_e ^+ 2) *: u +
    ((x.2 *d u) *: x.2) *+ 2 +
    (x.1 *: (x.2 *v u)) *+ 2)%:v.
 Proof.
@@ -882,7 +891,7 @@ move=> xu; rewrite /conjugation quat_vectZ -scalerAr -scalerAl.
 by rewrite -/(conjugation x x.2) conjugation_uquat.
 Qed.
 
-Lemma norm_conjugation x u : x \is uquat -> normq (conjugation x u) = norm u.
+Lemma norm_conjugation x u : x \is uquat -> normq (conjugation x u) = `|u|_e.
 Proof.
 rewrite qualifE => /eqP x1; rewrite /conjugation 2!normqM normqc x1; Simp.r.
 by rewrite normq_vector.
@@ -905,18 +914,18 @@ Proof. by rewrite /quat_of_polar cospi sinpi scale0r. Qed.
 Lemma quat_of_polarpihalf v : quat_of_polar (pi / 2%:R) v = v%:v.
 Proof. by rewrite /quat_of_polar cos_pihalf sin_pihalf scale1r. Qed.
 
-Lemma uquat_of_polar a v (v1 : norm v = 1) : quat_of_polar a v \is uquat.
+Lemma uquat_of_polar a v (v1 : `|v|_e = 1) : quat_of_polar a v \is uquat.
 Proof.
-by rewrite uquatE /quat_of_polar /sqrq /= normZ v1 mulr1 sqr_normr cos2Dsin2.
+by rewrite uquatE /quat_of_polar /sqrq /= enormZ v1 mulr1 sqr_normr cos2Dsin2.
 Qed.
 
 Definition quat_rot x v : 'rV[R]_3 := (conjugation x v).2.
 
-Lemma conjugation_quat_of_polar_axis v a : norm v = 1 ->
+Lemma conjugation_quat_of_polar_axis v a : `|v|_e = 1 ->
   quat_rot (quat_of_polar a v) v = v.
 Proof.
 move=> v1.
-rewrite /quat_rot conjugationE /= normZ exprMn v1 expr1n mulr1 sqr_normr.
+rewrite /quat_rot conjugationE /= enormZ exprMn v1 expr1n mulr1 sqr_normr.
 rewrite dotmulZv dotmulvv v1 expr1n mulr1 linearZl_LR (@liexx _ (vec3 R)) /= 2!scaler0 mul0rn.
 rewrite addr0 scalerA -expr2 mulr2n scalerBl addrA subrK -scalerDl cos2Dsin2.
 by rewrite scale1r.
@@ -928,8 +937,8 @@ Lemma conjugation_quat_of_polar_frame_j (f : frame R) a :
   quat_rot (quat_of_polar a f~i) f~j =
   cos (a *+ 2) *: f~j + sin (a *+ 2) *: f~k.
 Proof.
-rewrite /quat_rot conjugationE /= normZ noframe_norm mulr1 sqr_normr dotmulZv.
-have v0 : f~i != 0 by rewrite -norm_eq0 noframe_norm oner_neq0.
+rewrite /quat_rot conjugationE /= enormZ noframe_norm mulr1 sqr_normr dotmulZv.
+have v0 : f~i != 0 by rewrite -enorm_eq0 noframe_norm oner_neq0.
 rewrite (noframe_idotj f) mulr0 scale0r mul0rn addr0 linearZl_LR /=.
 rewrite (frame_icrossj f) scalerA [in RHS]mulr2n cosD sinD -!expr2.
 by congr (_ + _); rewrite (mulrC (sin a)) -mulr2n -scalerMnl.
@@ -939,8 +948,8 @@ Lemma conjugation_quat_of_polar_frame_k (f : frame R) a :
   quat_rot (quat_of_polar a f~i) f~k =
   - sin (a *+ 2) *: f~j + cos (a *+ 2) *: f~k.
 Proof.
-rewrite /quat_rot conjugationE /= normZ noframe_norm mulr1 sqr_normr dotmulZv.
-have v0 : f~i != 0 by rewrite -norm_eq0 noframe_norm oner_neq0.
+rewrite /quat_rot conjugationE /= enormZ noframe_norm mulr1 sqr_normr dotmulZv.
+have v0 : f~i != 0 by rewrite -enorm_eq0 noframe_norm oner_neq0.
 rewrite (noframe_idotk f) mulr0 scale0r mul0rn addr0 linearZl_LR /=.
 rewrite (frame_icrossk f) 2!scalerN scalerA sinD cosD -!expr2 addrC scaleNr.
 by congr (_ + _); rewrite (mulrC (sin a)) -mulr2n -scalerMnl mulNrn.
@@ -951,18 +960,18 @@ Definition polar_of_quat x : (R * 'rV_3)%type :=
     if x.1 == 1 then (0, 'e_1) else (pi, 'e_1)
   else if x.1 == 0 then (pi / 2%:R, x.2) else
   let: u := normalize x.2 in
-  let: a := atan (norm x.2 / x.1) in
+  let: a := atan (`|x.2|_e / x.1) in
   if 0 < x.1 then (a, u) else (a + pi, u).
 
 Lemma polar_of_quat0 : polar_of_quat 0 = (pi, 'e_1).
 Proof. by rewrite /polar_of_quat eqxx eq_sym oner_eq0. Qed.
 
-Lemma norm_polar_of_quat x : x \is uquat -> norm (polar_of_quat x).2 = 1.
+Lemma norm_polar_of_quat x : x \is uquat -> `|(polar_of_quat x).2|_e = 1.
 Proof.
 case: x => a0 a1; rewrite /= qualifE /polar_of_quat /normq /sqrq /=.
-have [/eqP ->|a10] := ifPn; first by case: ifPn; rewrite norm_delta_mx.
+have [/eqP ->|a10] := ifPn; first by case: ifPn; rewrite enorm_delta_mx.
 case: (sgzP a0) => [-> /eqP| |]; try by rewrite norm_normalize.
-by rewrite expr0n add0r sqrtr_sqr ger0_norm // norm_ge0.
+by rewrite expr0n add0r sqrtr_sqr ger0_norm // enorm_ge0.
 Qed.
 
 Lemma polar_of_quatK x : x \is uquat ->
@@ -970,7 +979,7 @@ Lemma polar_of_quatK x : x \is uquat ->
 Proof.
 case: x => a0 a1; rewrite /= qualifE /polar_of_quat /normq /sqrq /=.
 have [->|/eqP a1N u1] := a1 =P 0.
-  rewrite norm0 expr0n addr0 sqrtr_sqr; have [?/eqP->|?|_] := ltrgt0P a0.
+  rewrite enorm0 expr0n addr0 sqrtr_sqr; have [?/eqP->|?|_] := ltrgt0P a0.
   - by rewrite eqxx quat_of_polar01.
   - by rewrite eqr_oppLR => /eqP ->; rewrite eqrNxx oner_eq0 quat_of_polarpi1.
   - by rewrite eq_sym oner_eq0.
@@ -1006,7 +1015,7 @@ Qed.
 
 HB.instance Definition _ x := @GRing.isLinear.Build _ _ _ _ _ (quat_rot_is_linear x).
 
-Lemma quat_rot_isRot_polar v a : norm v = 1 ->
+Lemma quat_rot_isRot_polar v a : `|v|_e = 1 ->
   isRot (a *+2) v (quat_rot (quat_of_polar a v)).
 Proof.
 move=> v1 /=.

--- a/rigid.v
+++ b/rigid.v
@@ -1,4 +1,4 @@
-(* coq-robot (c) 2017 AIST and INRIA. License: LGPL-2.1-or-later. *)
+(* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From HB Require Import structures.
 From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
@@ -6,8 +6,8 @@ From mathcomp Require Import realalg complex finset fingroup perm.
 From mathcomp Require Import interval reals trigo.
 Require Import ssr_ext euclidean skew vec_angle rot frame extra_trigo.
 
-(******************************************************************************)
-(*                        Rigid Body Transformations                          *)
+(**md**************************************************************************)
+(* # Rigid Body Transformations                                               *)
 (*                                                                            *)
 (* This file develops the theory of isometries, proving basic properties such *)
 (* as the preservation of the cross-product by derivative maps, the facts     *)
@@ -16,6 +16,7 @@ Require Import ssr_ext euclidean skew vec_angle rot frame extra_trigo.
 (* body transformations are represented by elements of the special Euclidean  *)
 (* group and are shown to preserve norms.                                     *)
 (*                                                                            *)
+(* ```                                                                        *)
 (*      'Iso[T]_n == the type of isometries                                   *)
 (*     'CIso[T]_n == the type of central isometries, i.e., isometries f such  *)
 (*                   that f 0 = 0                                             *)
@@ -38,6 +39,7 @@ Require Import ssr_ext euclidean skew vec_angle rot frame extra_trigo.
 (*                   homogeneous representation                               *)
 (*      Adjoint g == adjoint transformation associated with the homogeneous   *)
 (*                   matrix g                                                 *)
+(* ```                                                                        *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -64,7 +66,7 @@ Section isometry.
 Variables (T : rcfType) (n : nat).
 Record t := mk {
   f :> 'rV[T]_n -> 'rV[T]_n ;
-  P : {mono f : a b / norm (a - b)} }.
+  P : {mono f : a b / `|a - b|_e} }.
 End isometry.
 End Iso.
 
@@ -90,17 +92,17 @@ Section central_isometry_n.
 Variable (T : rcfType) (n : nat).
 Implicit Types  f : 'CIso[T]_n.
 
-Lemma central_isometry_preserves_norm f : {mono f : x / norm x}.
+Lemma central_isometry_preserves_enorm f : {mono f : x / `|x|_e}.
 Proof. by case: f => f f0 p; rewrite -(subr0 (f p)) -f0 Iso.P subr0. Qed.
 
 (* [oneill] first part of lemma 1.6, p.100 *)
 Lemma central_isometry_preserves_dotmul f : {mono f : u v / u *d v}.
 Proof.
 case: f => f f0 a b.
-have /eqP : norm (f a - f b) = norm (a - b) by rewrite (Iso.P f).
-rewrite /norm eqr_sqrt ?le0dotmul // !dotmulDl !dotmulDr !dotmulvv !normN.
-rewrite !(central_isometry_preserves_norm (CIso.mk f0)) !addrA.
-rewrite 2!(addrC _ (norm b ^+ 2)) => /eqP/addrI.
+have /eqP : `|f a - f b|_e = `|a - b|_e by rewrite (Iso.P f).
+rewrite /enorm eqr_sqrt ?le0dotmul // !dotmulDl !dotmulDr !dotmulvv !enormN.
+rewrite !(central_isometry_preserves_enorm (CIso.mk f0)) !addrA.
+rewrite 2!(addrC _ (`|b|_e ^+ 2)) => /eqP/addrI.
 rewrite -2!addrA => /addrI.
 rewrite -(dotmulC (f a)) dotmulvN -(dotmulC a) dotmulvN -2!mulr2n => /eqP.
 rewrite -mulr_natr -[in X in _ == X -> _]mulr_natr 2!mulNr eqr_opp.
@@ -119,7 +121,7 @@ Local Open Scope frame_scope.
 Definition frame_central_iso f (F : noframe T) : noframe T.
 apply: (@NOFrame.mk _ (col_mx3 (f F~i) (f F~j) (f F~k))).
 apply/orthogonal3P.
-by rewrite !rowK /= 3!central_isometry_preserves_norm 3!noframe_norm
+by rewrite !rowK /= 3!central_isometry_preserves_enorm 3!noframe_norm
   3!central_isometry_preserves_dotmul idotj noframe_idotk jdotk !eqxx.
 Defined.
 
@@ -163,7 +165,7 @@ Lemma trans_ortho_of_iso f :
 Proof.
 set m := f 0.
 set Tm1f := fun x => f x - m.
-have Tm1f_is_iso : {mono Tm1f : a b / norm (a - b)}.
+have Tm1f_is_iso : {mono Tm1f : a b / `|a - b|_e}.
   move=> ? ?; by rewrite /Tm1f -addrA opprB 2!addrA subrK (Iso.P f).
 have Tm1f0 : Tm1f 0 = 0 by rewrite /Tm1f subrr.
 set c := @CIso.mk _ _ (Iso.mk Tm1f_is_iso) Tm1f0.
@@ -286,7 +288,7 @@ Lemma dmapE f (u : vector) b a :
 Proof. move=> uab; by rewrite /dmap /= uab img_vec_iso. Qed.
 
 Lemma derivative_map_preserves_length f :
-  {mono (fun x : vector => f`* x) : u v / norm (u - v)}.
+  {mono (fun x : vector => f`* x) : u v / `|u - v|_e}.
 Proof.
 move=> u v; rewrite /dmap /= -(mulmxBl u v (ortho_of_iso f)).
 by rewrite orth_preserves_norm // ortho_of_iso_is_O.
@@ -352,7 +354,7 @@ apply (@NOFrame.mk _ (col_mx3 e1 e2 e3)).
   apply/orthogonal3P; rewrite !rowK /=.
   do 3! rewrite orth_preserves_norm ?ortho_of_iso_is_O //.
   rewrite /u1p /u2p /u3p.
-  rewrite !rowframeE !rowE !mulmx1 3!normeE !eqxx /=.
+  rewrite !rowframeE !rowE !mulmx1 3!enormeE !eqxx /=.
   rewrite !(proj2 (orth_preserves_dotmul _)) ?ortho_of_iso_is_O //.
   rewrite /u1p /u2p /u3p.
   by rewrite !rowframeE /= !rowE ?mulmx1 !dote2 //= eqxx.
@@ -1001,8 +1003,8 @@ Qed.
 
 End euclidean_motion.
 
-Lemma motion_vector_preserves_norm (T : realType) (m : t T) :
-  {mono (motion_vector m) : u / norm u}.
+Lemma motion_vector_preserves_enorm (T : realType) (m : t T) :
+  {mono (motion_vector m) : u / `|u|_e}.
 Proof.
 move=> ?; rewrite motion_vectorE orth_preserves_norm // rotation_sub //.
 exact: rotP.
@@ -1026,8 +1028,8 @@ case/boolP : (Aa.angle M == 0) => a0.
 transitivity (u *m M); last first.
   (* TODO: lemma? *)
   by rewrite motion_pointE /= (mul_mx_row u) mulmx0 add_row_mx addr0 add0r to_hpointK.
-have w1 : norm w = 1.
- by rewrite /w aaxis_of // ?Aa.vaxis_neq0 // norm_normalize // Aa.vaxis_neq0.
+have w1 : `|w|_e = 1.
+ by rewrite /w aaxis_of ?Aa.vaxis_neq0// norm_normalize // Aa.vaxis_neq0.
 rewrite rodriguesP //; congr (_ *m _) => {u}.
 by rewrite (angle_axis_eskew_old MSO) // Aa.vaxis_neq0.
 Qed.
@@ -1089,11 +1091,11 @@ by rewrite mul_mx_row mulmx0 add_row_mx add0r to_hpointK.
 Qed.
 
 Lemma SE_preserves_length m :
-  {mono (EuclideanMotion.motion_point m) : a b / norm (a - b)}.
+  {mono (EuclideanMotion.motion_point m) : a b / `|a - b|_e}.
 Proof.
 move=> m0 m1.
 rewrite EuclideanMotion.motion_pointB.
-by rewrite EuclideanMotion.motion_vector_preserves_norm.
+by rewrite EuclideanMotion.motion_vector_preserves_enorm.
 Qed.
 
 Lemma ortho_of_isoE m :

--- a/robot-rocq.opam
+++ b/robot-rocq.opam
@@ -26,7 +26,7 @@ depends: [
   "coq-mathcomp-algebra" { (>= "2.5.0") }
   "coq-mathcomp-solvable" { (>= "2.5.0") }
   "coq-mathcomp-field" { (>= "2.5.0") }
-  "coq-mathcomp-analysis" { (>= "1.11.0") }
+  "coq-mathcomp-analysis" { (>= "1.15.0") }
   "coq-mathcomp-real-closed" { (>= "2.0.0") }
   "coq-mathcomp-algebra-tactics" { (>= "1.2.4") }
 ]

--- a/rot.v
+++ b/rot.v
@@ -1,4 +1,4 @@
-(* coq-robot (c) 2017 AIST and INRIA. License: LGPL-2.1-or-later. *)
+(* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From HB Require Import structures.
 From Stdlib Require Import NsatzTactic.
 From mathcomp Require Import all_boot order ssralg ssrint ssrnum rat poly.
@@ -10,17 +10,20 @@ From mathcomp Require Import sesquilinear.
 Require Import extra_trigo.
 Require Import ssr_ext euclidean skew vec_angle frame.
 
-(******************************************************************************)
-(*                              Rotations                                     *)
+(**md**************************************************************************)
+(* # Rotations                                                                *)
 (*                                                                            *)
 (* This file develops the theory of 3D rotations with results such as         *)
 (* Rodrigues formula, the fact that any rotation matrix can be represented    *)
 (* by its exponential coordinates, angle-axis representation, Euler angles,   *)
 (* etc. See also quaternion.v for rotations using quaternions.                *)
 (*                                                                            *)
+(* ```                                                                        *)
 (*  RO a, RO' a == two dimensional rotations of angle a                       *)
+(* ```                                                                        *)
 (*                                                                            *)
 (* Elementary rotations (row vector convention):                              *)
+(* ```                                                                        *)
 (*  Rx a, Rx' a == rotations about axis x of angle a                          *)
 (*  Ry a == rotation about axis y of angle a                                  *)
 (*  Rz a == rotation about axis z of angle a                                  *)
@@ -29,7 +32,9 @@ Require Import ssr_ext euclidean skew vec_angle frame.
 (*    sample lemmas:                                                          *)
 (*    all rotations around a vector of angle a have trace "1 + 2 * cos a"     *)
 (*    equivalence SO[R]_3 <-> Rot (isRot_SO, SO_is_Rot)                       *)
+(* ```                                                                        *)
 (*                                                                            *)
+(* ```                                                                        *)
 (*   `e(a, M) == specialized exponential map for angle a and matrix M         *)
 (*  `e^(a, w) == specialized exponential map for the matrix \S(w), i.e., the  *)
 (*               skew-symmetric matrix corresponding to vector w              *)
@@ -37,40 +42,52 @@ Require Import ssr_ext euclidean skew vec_angle frame.
 (*    inverse of the exponential map,                                         *)
 (*    exponential map of a skew matrix is a rotation                          *)
 (*                                                                            *)
+(* ```                                                                        *)
 (* rodrigues u a w == linear combination of the vectors u, (u *d w)w, w *v u  *)
 (*                    that provides an alternative expression for the vector  *)
 (*                    u * e^(a,w)                                             *)
+(* ```                                                                        *)
 (*                                                                            *)
 (* Angle-axis representation:                                                 *)
+(* ```                                                                        *)
 (*   Aa.angle M == angle of angle-axis representation for the matrix M        *)
 (*   Aa.vaxis M == axis of angle-axis representation for the matrix M         *)
 (*    sample lemma                                                            *)
 (*    a rotation matrix has Aa.angle M and normalize (Aa.vaxis M) for         *)
 (*    exponential coordinates                                                 *)
+(* ```                                                                        *)
 (*                                                                            *)
 (* Composition of elementary rotations (row vector convention):               *)
+(* ```                                                                        *)
 (*   Rzyz a b c == composition of a Rz rotation of angle c, a Ry rotation of  *)
 (*                 angle b, and a Rz rotation of angle a                      *)
 (*   Rxyz a b c == composition of a Rx rotation of angle c, a Ry rotation of  *)
 (*                 angle b, and a Rz notation of angle a                      *)
+(* ```                                                                        *)
 (*                                                                            *)
 (* ZYZ angles given a rotation matrix M (ref: [sciavicco] 2.4.1):             *)
 (* with zyz_b in ]0;pi[:                                                      *)
+(* ```                                                                        *)
 (*   zyz_a M == angle of the last Rz rotation                                 *)
 (*   zyz_b M == angle of the Ry rotation                                      *)
 (*   zyz_c M == angle of the first Rz rotation                                *)
+(* ```                                                                        *)
 (*                                                                            *)
 (* Roll-Pitch-Yaw (ZYX) angles given a rotation matrix M                      *)
 (* with pitch in ]-pi/2;pi/2[ (ref: [sciavicco] 2.4.2):                       *)
+(* ```                                                                        *)
 (*   rpy_a M == angle about axis z (roll)                                     *)
 (*   rpy_b M == angle about axis y (pitch)                                    *)
 (*   rpy_c M == angle about axis x (yaw)                                      *)
+(* ```                                                                        *)
 (*                                                                            *)
 (* Alternative formulation of ZYX angles:                                     *)
 (* (ref: [Gregory G. Slabaugh, Computer Euler angles from a rotation matrix]) *)
+(* ```                                                                        *)
 (*   euler_a == angle about z                                                 *)
 (*   euler_b == angle about y                                                 *)
 (*   euler_c == angle about x                                                 *)
+(* ```                                                                        *)
 (******************************************************************************)
 
 Reserved Notation "'`e(' a ',' M ')'" (format "'`e(' a ','  M ')'").
@@ -138,8 +155,8 @@ Lemma rot2d M : M \is 'SO[T]_2 -> {a | - pi < a <= pi & M = RO a}.
 Proof.
 move=> MSO.
 move: (MSO); rewrite rotationE => /andP[MO _].
-case: (norm1_cossin (norm_row_of_O MO 0)); rewrite !mxE => a [a1 a2].
-case: (norm1_cossin (norm_row_of_O MO 1)); rewrite !mxE => b [b1 b2].
+case: (enorm1_cossin (enorm_row_of_O MO 0)); rewrite !mxE => a [a1 a2].
+case: (enorm1_cossin (enorm_row_of_O MO 1)); rewrite !mxE => b [b1 b2].
 move/orthogonalP : (MO) => /(_ 0 1) /=.
 rewrite dotmulE sum2E !mxE a1 a2 b1 b2 -cosB => cE.
 have : `|sin (a - b)| = 1 by apply: cos0sin1.
@@ -178,8 +195,8 @@ Lemma rot2d' M :
              { - pi < a <= pi /\ M = RO' a}}.
 Proof.
 move=> MO.
-case: (norm1_cossin (norm_row_of_O MO 0)); rewrite !mxE => a [a1 a2].
-case: (norm1_cossin (norm_row_of_O MO 1)); rewrite !mxE => b [b1 b2].
+case: (enorm1_cossin (enorm_row_of_O MO 0)); rewrite !mxE => a [a1 a2].
+case: (enorm1_cossin (enorm_row_of_O MO 1)); rewrite !mxE => b [b1 b2].
 move/orthogonalP : (MO) => /(_ 0 1) /=.
 rewrite dotmulE sum2E !mxE a1 a2 b1 b2 -cosB.
 have HM : M = col_mx2 (row2 (cos a) (sin a)) (row2 (cos b) (sin b)).
@@ -278,9 +295,9 @@ Definition Ry a := col_mx3
 Lemma Ry_is_SO a : Ry a \is 'SO[T]_3.
 Proof.
 apply/rotation3P/and4P; split.
-- rewrite -(@eqrXn2 _ 2) // ?norm_ge0 // expr1n.
+- rewrite -(@eqrXn2 _ 2) // ?enorm_ge0 // expr1n.
   by rewrite -dotmulvv dotmulE sum3E !mxE /= mulr0 addr0 -2!expr2 sqrrN cos2Dsin2.
-- rewrite -(@eqrXn2 _ 2) // ?norm_ge0 // expr1n.
+- rewrite -(@eqrXn2 _ 2) // ?enorm_ge0 // expr1n.
    by rewrite -dotmulvv dotmulE sum3E !mxE /= mulr0 addr0 add0r mulr1.
 - by rewrite 2!rowK /= dotmulE sum3E !mxE /= !mulr0 mul0r !add0r.
 - rewrite 3!rowK /= crossmulE !mxE /=. by Simp.r.
@@ -316,9 +333,9 @@ Qed.
 Lemma Rz_is_SO a : Rz a \is 'SO[T]_3.
 Proof.
 apply/rotation3P/and4P; split.
-- rewrite -(@eqrXn2 _ 2) // ?norm_ge0 // expr1n.
+- rewrite -(@eqrXn2 _ 2) ?enorm_ge0// expr1n.
   by rewrite -dotmulvv dotmulE sum3E !mxE /= mulr0 addr0 -2!expr2 cos2Dsin2.
-- rewrite -(@eqrXn2 _ 2) // ?norm_ge0 // expr1n.
+- rewrite -(@eqrXn2 _ 2) ?enorm_ge0// expr1n.
 - by rewrite -dotmulvv dotmulE sum3E !mxE /= mulr0 addr0 mulrN mulNr opprK addrC cos2Dsin2.
 - by rewrite 2!rowK /= dotmulE sum3E !mxE /= mulrN mulr0 addr0 addrC mulrC subrr.
 - rewrite 3!rowK /= crossmulE !mxE /=. Simp.r. by rewrite -!expr2 cos2Dsin2 e2row.
@@ -328,8 +345,8 @@ Lemma RzE a : Rz a = (frame_of_SO (Rz_is_SO a)) _R^ (can_frame T).
 Proof. rewrite FromTo_to_can; by apply/matrix3P/and9P; split; rewrite !mxE. Qed.
 
 Lemma rmap_Rz_e0 a :
-  rmap (can_tframe T) `[ 'e_0 $ frame_of_SO (Rz_is_SO a) ] =
-                      `[ row 0 (Rz a) $ can_tframe T ].
+  rmap (can_tframe T) '[ 'e_0 $ frame_of_SO (Rz_is_SO a) ] =
+                      '[ row 0 (Rz a) $ can_tframe T ].
 Proof. by rewrite rmapE_to_can rowE [in RHS]RzE FromTo_to_can. Qed.
 
 Definition Rzy a b := col_mx3
@@ -389,7 +406,7 @@ by rewrite cos0 sin0 mulmx1 scale0r addr0 scale1r.
 by rewrite mulmx1 sin0 cos0 scaleNr scale0r oppr0 add0r scale1r.
 Qed.
 
-Lemma isRotpi (u1 : norm u = 1) : isRot pi u (mx_lin1 (u^T *m u *+ 2 - 1)).
+Lemma isRotpi (u1 : `|u|_e = 1) : isRot pi u (mx_lin1 (u^T *m u *+ 2 - 1)).
 Proof.
 apply/isRotP; split => /=.
 - by rewrite mulmxBr mulmx1 mulr2n mulmxDr mulmxA dotmul1 // ?mul1mx addrK.
@@ -552,8 +569,8 @@ have cd : k *m M = c *: j + d *: k.
   by rewrite {1}(orthogonal_expansion (Base.frame e) (k *m M)) dotmulC iMk
     scale0r add0r.
 have H1 : a ^+ 2 + b ^+ 2 = 1.
-  move/eqP: (norm_row_of_O (NOFrame.MO (Base.frame e)) 1).
-  rewrite -(@eqrXn2 _ 2) // ?norm_ge0 // expr1n -dotmulvv.
+  move/eqP: (enorm_row_of_O (NOFrame.MO (Base.frame e)) 1).
+  rewrite -(@eqrXn2 _ 2) ?enorm_ge0// expr1n -dotmulvv.
   rewrite -(proj2 (orth_preserves_dotmul M) (rotation_sub MSO)).
   rewrite -rowframeE ab dotmulDr 2!dotmulDl 4!dotmulvZ 4!dotmulZv 2!dotmulvv.
   by rewrite normj // normk // !(expr1n,mulr1) -!expr2 dotmulC jdotk // !(mulr0,add0r,addr0) => /eqP.
@@ -563,8 +580,8 @@ have H2 : a * c + b * d = 0.
   rewrite dotmulDr 2!dotmulDl 4!dotmulvZ 4!dotmulZv 2!dotmulvv normj // normk //.
   by rewrite expr1n !mulr1 dotmulC jdotk // 4!mulr0 add0r addr0 mulrC (mulrC d) => /eqP.
 have H3 : c ^+ 2 + d ^+ 2 = 1.
-  move/eqP: (norm_row_of_O (NOFrame.MO (Base.frame e)) 2%:R).
-  rewrite -(@eqrXn2 _ 2) // ?norm_ge0 // expr1n -dotmulvv.
+  move/eqP: (enorm_row_of_O (NOFrame.MO (Base.frame e)) 2%:R).
+  rewrite -(@eqrXn2 _ 2) ?enorm_ge0// expr1n -dotmulvv.
   rewrite -(proj2 (orth_preserves_dotmul M) (rotation_sub MSO)) -!rowframeE -/k cd.
   rewrite dotmulDr 2!dotmulDl 4!dotmulvZ 4!dotmulZv 2!dotmulvv normj // normk //.
   by rewrite expr1n 2!mulr1 -2!expr2 dotmulC jdotk // !(mulr0,addr0,add0r) => /eqP.
@@ -677,7 +694,7 @@ Qed.
 
 Local Notation "'`e^(' a ',' w ')'" := (emx3 a \S( w )).
 
-Lemma eskew_pi w : norm w = 1 -> `e^(pi, w) = w^T *m w *+ 2 - 1.
+Lemma eskew_pi w : `| w |_e = 1 -> `e^(pi, w) = w^T *m w *+ 2 - 1.
 Proof.
 move=> w1.
 rewrite /emx3 sinpi scale0r addr0 cospi opprK -(natrD _ 1 1).
@@ -687,7 +704,7 @@ by rewrite (_ : 1%:A = 1) // ?subrCA ?subrr ?addr0 // -idmxE scale1r.
 Qed.
 
 Lemma eskew_pi' w a :
-  norm w = 1 -> cos a = -1 -> sin a = 0 -> `e^(a, w) = w^T *m w *+ 2 - 1.
+  `| w |_e = 1 -> cos a = -1 -> sin a = 0 -> `e^(a, w) = w^T *m w *+ 2 - 1.
 Proof.
 move=> w1 Hs Hc.
 rewrite /emx3 Hs Hc scale0r addr0 opprK -(natrD _ 1 1).
@@ -708,10 +725,10 @@ Qed.
 Lemma tr_eskew a w : `e^(a, w)^T = `e^(a, - w).
 Proof. by rewrite tr_emx3 tr_spin /emx3 spinN. Qed.
 
-Lemma eskewM a b w : norm w = 1 -> `e^(a, w) * `e^(b, w) = `e^(a + b, w).
+Lemma eskewM a b w : `| w |_e = 1 -> `e^(a, w) * `e^(b, w) = `e^(a + b, w).
 Proof. move=> w1; by rewrite emx3M // spin3 w1 expr1n scaleN1r. Qed.
 
-Lemma trace_eskew a w : norm w = 1 -> \tr `e^(a, w) = 1 + 2%:R * cos a.
+Lemma trace_eskew a w : `| w |_e = 1 -> \tr `e^(a, w) = 1 + 2%:R * cos a.
 Proof.
 move=> w1.
 rewrite 2!mxtraceD !mxtraceZ /= mxtrace1.
@@ -736,7 +753,7 @@ Definition angle_axis_rot a u :=
         (u``_1 * u``_2%:R * va - u``_0 * sa)
         (u``_2%:R ^+2 * va + ca)).
 
-Lemma eskewE a u : norm u = 1 -> `e^(a, u) = angle_axis_rot a u.
+Lemma eskewE a u : `| u |_e = 1 -> `e^(a, u) = angle_axis_rot a u.
 Proof.
 pose va := 1 - cos a. pose ca := cos a. pose sa := sin a.
 move=> w1; apply/matrix3P/and9P; split; apply/eqP.
@@ -775,18 +792,18 @@ move=> w1; apply/matrix3P/and9P; split; apply/eqP.
   by rewrite /va opprB addrC subrK.
 Qed.
 
-Lemma eskew_is_O a u : norm u = 1 -> `e^(a, u) \is 'O[T]_3.
+Lemma eskew_is_O a u : `| u |_e = 1 -> `e^(a, u) \is 'O[T]_3.
 Proof.
 move=> u1.
 by rewrite orthogonalE tr_emx3 tr_spin inv_emx3 // exp_spin u1 expr1n scaleN1r.
 Qed.
 
-Lemma rank_eskew a w : norm w = 1 -> \rank `e^(a, w) = 3%N.
+Lemma rank_eskew a w : `| w |_e = 1 -> \rank `e^(a, w) = 3%N.
 Proof.
 move=> w1; by rewrite mxrank_unit // orthogonal_unit // eskew_is_O.
 Qed.
 
-Lemma det_eskew a w : norm w = 1 -> \det `e^(a, w) = 1.
+Lemma det_eskew a w : `| w |_e = 1 -> \det `e^(a, w) = 1.
 Proof.
 move=> w1.
 move/orthogonal_det/eqP : (eskew_is_O (a / 2%:R) w1).
@@ -795,7 +812,7 @@ rewrite mulmxE emx3M; last by rewrite spin3 w1 expr1n scaleN1r.
 by move/eqP; rewrite -splitr.
 Qed.
 
-Lemma eskew_is_SO a w : norm w = 1 -> `e^(a, w) \is 'SO[T]_3.
+Lemma eskew_is_SO a w : `| w |_e = 1 -> `e^(a, w) \is 'SO[T]_3.
 Proof. by move=> w1; rewrite rotationE eskew_is_O //= det_eskew. Qed.
 
 Definition expi a := (cos a +i* sin a)%C.
@@ -811,7 +828,7 @@ Proof. by rewrite /expi cos0 sin0. Qed.
 
 Definition eskew_eigenvalues a : seq T[i] := [:: 1; expi a; expi (- a)].
 
-Lemma eigenvalue_ekew a w : norm w = 1 ->
+Lemma eigenvalue_ekew a w : `| w |_e = 1 ->
   eigenvalue (map_mx (fun x => x%:C%C) `e^(a, w)) =1
     [pred k | k \in eskew_eigenvalues a].
 Proof.
@@ -859,7 +876,7 @@ Qed.
 
 Lemma Rz_eskew a : Rz a = `e^(a, 'e_2%:R).
 Proof.
-rewrite /Rz eskewE /angle_axis_rot ?norm_delta_mx //.
+rewrite /Rz eskewE /angle_axis_rot ?enorm_delta_mx //.
 rewrite !mxE /= expr0n /=. Simp.r.
 by rewrite expr1n mul1r subrK -e2row.
 Qed.
@@ -874,7 +891,7 @@ Qed.
 Section rodrigues_formula.
 
 Definition rodrigues u a w :=
-  u - (1 - cos a) *: (norm w ^+ 2 *: u) + (1 - cos a) * (u *d w) *: w + sin a *: (w *v u).
+  u - (1 - cos a) *: (`|w|_e ^+ 2 *: u) + (1 - cos a) * (u *d w) *: w + sin a *: (w *v u).
 
 Lemma rodriguesP u a w : rodrigues u a w = u *m `e^(a, w).
 Proof.
@@ -892,7 +909,7 @@ Qed.
 Definition rodrigues_unit u a w :=
   cos a *: u + (1 - cos a) * (u *d w) *: w + sin a *: (w *v u).
 
-Lemma rodrigues_unitP u a w : norm w = 1 -> rodrigues_unit u a w = u *m `e^(a, w).
+Lemma rodrigues_unitP u a w : `|w|_e = 1 -> rodrigues_unit u a w = u *m `e^(a, w).
 Proof.
 move=> w1; rewrite -(rodriguesP u a w).
 rewrite /rodrigues /rodrigues_unit w1 expr1n scale1r; congr (_ + _ + _).
@@ -907,7 +924,7 @@ move=> w0.
 pose f := Base.frame w.
 apply/isRotP; split => /=.
 - rewrite -rodriguesP // /rodrigues (norm_normalize w0) expr1n scale1r.
-  rewrite dotmul_normalize_norm scalerA -mulrA divrr ?mulr1 ?unitfE ?norm_eq0 //.
+  rewrite dotmul_normalize_enorm scalerA -mulrA divrr ?mulr1 ?unitfE ?enorm_eq0//.
   by rewrite subrK (linearZl_LR _ w)/= (@liexx _ (vec3 T)) 2!scaler0 addr0.
 - rewrite -rodriguesP // /rodrigues dotmulC norm_normalize // expr1n scale1r.
   rewrite (_ : normalize w = Base.i w) (*NB: lemma?*); last by rewrite /Base.i (negbTE w0).
@@ -922,10 +939,11 @@ apply/isRotP; split => /=.
   by rewrite -/(Base.i w) Base.icrossk // scalerN scaleNr.
 Qed.
 
-Lemma isRot_eskew a w w' : normalize w' = w -> norm w = 1 -> isRot a w' (mx_lin1 `e^(a, w)).
+Lemma isRot_eskew a w w' : normalize w' = w -> `|w|_e = 1 ->
+  isRot a w' (mx_lin1 `e^(a, w)).
 Proof.
 move=> <- w1.
-by rewrite isRot_eskew_normalize // -normalize_eq0 -norm_eq0 w1 oner_eq0.
+by rewrite isRot_eskew_normalize // -normalize_eq0 -enorm_eq0 w1 oner_eq0.
 Qed.
 
 Lemma eskew_is_onto_SO M : M \is 'SO[T]_3 ->
@@ -935,12 +953,12 @@ move=> MSO.
 set w : vector := normalize _.
 case: (SO_isRot MSO) => a aB Ha.
 exists a => //.
-apply: (@same_isRot _ _ _ _ _ (norm (vaxis_euler M)) _ _ _ _ Ha); last first.
+apply: (@same_isRot _ _ _ _ _ `|vaxis_euler M|_e _ _ _ _ Ha); last first.
   apply (@isRot_eskew _ _ w).
   by rewrite normalizeI // norm_normalize // vaxis_euler_neq0.
   by rewrite norm_normalize // vaxis_euler_neq0.
 by rewrite norm_scale_normalize.
-by rewrite norm_gt0 vaxis_euler_neq0.
+by rewrite enorm_gt0 vaxis_euler_neq0.
 by rewrite vaxis_euler_neq0.
 Qed.
 
@@ -950,7 +968,7 @@ Section alternative_definition_of_eskew.
 Definition eskew_unit (a : T) (e : 'rV[T]_3) :=
   e^T *m e + (cos a) *: (1 - e^T *m e) + sin a *: \S( e ).
 
-Lemma eskew_unitE w (a : T) : norm w = 1 -> eskew_unit a w = `e^(a, w).
+Lemma eskew_unitE w (a : T) : `| w |_e = 1 -> eskew_unit a w = `e^(a, w).
 Proof.
 move=> w1.
 rewrite /eskew_unit /emx3 addrAC sqr_spin -addrA addrCA.
@@ -963,7 +981,7 @@ Qed.
 Local Open Scope frame_scope.
 
 (* TODO: move? *)
-Lemma normalcomp_double_crossmul p (e : 'rV[T]_3) : norm e = 1 ->
+Lemma normalcomp_double_crossmul p (e : 'rV[T]_3) : `| e |_e = 1 ->
   normalcomp p e *v ((Base.frame e)|,2%:R *v (Base.frame e)|,1) = e *v p.
 Proof.
 move=> u1.
@@ -975,7 +993,7 @@ rewrite crossmul_axialcomp add0r (@lieC _ (vec3 T)) /=.
 by rewrite (linearNl _ (normalcomp p e))/= opprK.
 Qed.
 
-Lemma normalcomp_mulO' a Q u p : norm u = 1 -> isRot a u (mx_lin1 Q) ->
+Lemma normalcomp_mulO' a Q u p : `| u |_e = 1 -> isRot a u (mx_lin1 Q) ->
   normalcomp p u *m Q = cos a *: normalcomp p u + sin a *: (u *v p).
 Proof.
 move=> u1 H.
@@ -998,7 +1016,7 @@ by rewrite -double_crossmul normalcomp_double_crossmul.
 Qed.
 
 (* [angeles] p.42, eqn 2.49 *)
-Lemma isRot_eskew_unit_inv a Q u : norm u = 1 ->
+Lemma isRot_eskew_unit_inv a Q u : `| u |_e = 1 ->
   isRot a u (mx_lin1 Q) -> Q = eskew_unit a u.
 Proof.
 move=> u1 H; apply/eqP/mulmxP => p.
@@ -1039,7 +1057,7 @@ Lemma isRot_pi_inv (R : 'M[T]_3) u :
 Proof.
 move=> u0 H.
 have /isRot_eskew_unit_inv {H} : isRot pi (normalize u) (mx_lin1 R).
-  by rewrite isRotZ // invr_gt0 norm_gt0.
+  by rewrite isRotZ // invr_gt0 enorm_gt0.
 rewrite norm_normalize // => /(_ erefl) ->.
 by rewrite eskew_unitE ?norm_normalize // eskew_pi // norm_normalize.
 Qed.
@@ -1069,7 +1087,7 @@ Qed.
 
 
 (* reflection w.r.t. plan of normal u *)
-Lemma anglepi (n : vector) (n1 : norm n = 1) :
+Lemma anglepi (n : vector) (n1 : `| n |_e = 1) :
   angle (n^T *m n *+ 2 - 1) = pi.
 Proof.
 rewrite /angle mxtraceD linearN /= mxtrace1 mulr2n linearD /=.
@@ -1107,14 +1125,14 @@ case/eskew_is_onto_SO : (MSO) => a aB Ma.
 move: (Msym).
 rewrite {1}Ma /emx3.
 rewrite symE !linearD /= trmx1 /= !linearZ /= sqr_spin !linearD /=.
-do 2 rewrite (linearN _ (norm (normalize (vaxis_euler M)) ^+ 2)%:A)/=.
-rewrite (linearN _ (norm (normalize (vaxis_euler M)) ^+ 2)%:A^T)/=.
+do 2 rewrite (linearN _ (`|normalize (vaxis_euler M)|_e ^+ 2)%:A)/=.
+rewrite (linearN _ (`|normalize (vaxis_euler M)|_e ^+ 2)%:A^T)/=.
 rewrite trmx_mul trmxK scalemx1 tr_scalar_mx tr_spin.
 rewrite !addrA subr_eq subrK.
 rewrite [in X in _ == X]addrC -subr_eq0 !addrA !opprD !addrA addrK.
 rewrite scalerN opprK -addrA addrCA !addrA (addrC _ 1) subrr add0r.
 rewrite -mulr2n scalerMnl scaler_eq0 mulrn_eq0 /=.
-rewrite -spin0 spin_inj -norm_eq0 norm_normalize ?vaxis_euler_neq0 // oner_eq0 orbF.
+rewrite -spin0 spin_inj -enorm_eq0 norm_normalize ?vaxis_euler_neq0 // oner_eq0 orbF.
 move=> /eqP Hs.
 have := sin0cos1 Hs; case: (ler0P (cos a)) => _ Hc; move: Ma; last first.
   by rewrite emx30M' // => ->; rewrite angle1; left.
@@ -1160,7 +1178,7 @@ rewrite subrr add0r -(mulr_natr (cos a)) -mulrA divrr ?unitfE ?pnatr_eq0 // mulr
 split => Ha; by [rewrite cosK | rewrite cosKN].
 Qed.
 
-Lemma angle_eskew a u : norm u = 1 -> 0 <= a <= pi -> angle `e^(a, u) = a.
+Lemma angle_eskew a u : `|u|_e = 1 -> 0 <= a <= pi -> angle `e^(a, u) = a.
 Proof.
 move=> u1 Ha.
 rewrite /angle trace_eskew // addrAC subrr add0r.
@@ -1305,7 +1323,7 @@ by rewrite ?(acos_ge0, acos_lepi) // tr_interval.
 Qed.
 
 Lemma vaxis_eskew a (w : vector) :
-  sin a != 0 -> 0 <= a <= pi -> norm w = 1 -> vaxis `e^(a, w) = w.
+  sin a != 0 -> 0 <= a <= pi -> `|w|_e = 1 -> vaxis `e^(a, w) = w.
 Proof.
 move=> sphi Ha w1; rewrite /vaxis angle_eskew //.
 case: eqP => [aE|/eqP aD]; first by move: (sphi); rewrite aE sinpi eqxx.
@@ -1342,7 +1360,7 @@ Let vector := 'rV[T]_3.
 Definition log_rot (M : 'M[T]_3) : T * 'rV[T]_3 := (Aa.angle M, Aa.vaxis M).
 
 Lemma log_exp_eskew (a : T) (w : 'rV[T]_3) :
-  sin a != 0 -> 0 <= a <= pi -> norm w = 1 -> log_rot `e^(a, w) = (a, w).
+  sin a != 0 -> 0 <= a <= pi -> `|w|_e = 1 -> log_rot `e^(a, w) = (a, w).
 Proof.
 move=> ? ? ?; congr pair; by [rewrite Aa.angle_eskew | rewrite Aa.vaxis_eskew].
 Qed.
@@ -1364,7 +1382,7 @@ case/boolP : (Aa.angle M == 0) => [/eqP H|a0].
 case/boolP : (Aa.angle M == pi) => [/eqP H|api].
   rewrite H eskew_pi ?norm_normalize // /Aa.vaxis H eqxx ?vaxis_euler_neq0 //.
   exact: Aa.SO_pi_reflection.
-(* 
+(*
 have sina0 : sin (Aa.angle M) != 0.
   apply: contra a0 => /eqP/sin0_inv [->//|/eqP]; by rewrite (negbTE api).
 *)
@@ -1372,9 +1390,9 @@ set w : 'rV_3 := normalize _.
 have [a /andP[a_gtNpi a_lepi] Rota] := SO_isRot MSO.
 have {}Rota : isRot a (normalize (vaxis_euler M)) (mx_lin1 M).
   rewrite (isRotZ a _ (vaxis_euler_neq0 MSO)) //.
-  by rewrite invr_gt0 norm_gt0 vaxis_euler_neq0.
+  by rewrite invr_gt0 enorm_gt0 vaxis_euler_neq0.
 have w0 : normalize (vaxis_euler M) != 0 by rewrite normalize_eq0 vaxis_euler_neq0.
-have w1 : norm w = 1 by rewrite norm_normalize // Aa.vaxis_neq0.
+have w1 : `|w|_e = 1 by rewrite norm_normalize // Aa.vaxis_neq0.
 case: (leP 0 a) => Ha.
 - have aB1 : 0 <= a <= pi by rewrite Ha a_lepi.
   move: (Aa.isRot_angle w0 aB1 Rota) => a_angle_of_rot.
@@ -1388,8 +1406,8 @@ case: (leP 0 a) => Ha.
   have k0 : 0 < k.
     rewrite /k invr_gt0 pmulrn_lgt0 // lt_neqAle eq_sym sina0 /=.
     by apply: sin_ge0_pi.
-  have Hn : normalize (vaxis_euler M) = 
-            ((sin a *+ 2) * k) *: (norm (Aa.vaxis M) *: w).
+  have Hn : normalize (vaxis_euler M) =
+            ((sin a *+ 2) * k) *: (`|Aa.vaxis M|_e *: w).
     rewrite -(norm_scale_normalize (normalize (vaxis_euler M))).
     rewrite norm_normalize ?vaxis_euler_neq0 // w'axial.
     rewrite scale1r {2}/k divff ?mulrn_eq0 // scale1r.
@@ -1398,8 +1416,8 @@ case: (leP 0 a) => Ha.
     rewrite pmulr_rgt0 // pmulrn_lgt0 // lt_neqAle eq_sym sina0.
     by rewrite  sin_ge0_pi.
   rewrite -a_angle_of_rot isRot_eskew //.
-  rewrite normalizeZ ?normalizeI // -?norm_eq0 ?w1 ?oner_neq0 //.
-  by rewrite norm_gt0 ?Aa.vaxis_neq0.
+  rewrite normalizeZ ?normalizeI // -?enorm_eq0 ?w1 ?oner_neq0 //.
+  by rewrite enorm_gt0 ?Aa.vaxis_neq0.
 have aB1 : - pi <= a <= 0 by rewrite (ltW a_gtNpi) ltW.
 move: (Aa.isRot_angleN w0 aB1 Rota) => a_angle_of_rot.
   have : M \in unitmx by rewrite orthogonal_unit // rotation_sub // -rotationV.
@@ -1417,7 +1435,7 @@ have sa_gt0 : 0 < sin (Aa.angle M).
   by rewrite -oppr_gt0 -sinN sin_gt0_pi // oppr_cp0 Ha ltrNl.
 have se_neq0 : sin (Aa.angle M) != 0 by case: ltgtP sa_gt0.
 have k0 : 0 < k by rewrite /k invr_gt0 pmulrn_lgt0.
-apply: (@same_isRot _ _ _ _ (- norm (Aa.vaxis M) *: w) ((sin (Aa.angle M) *+ 2) * k) w0 _ (- Aa.angle M)).
+apply: (@same_isRot _ _ _ _ (- `|Aa.vaxis M|_e *: w) ((sin (Aa.angle M) *+ 2) * k) w0 _ (- Aa.angle M)).
 - by rewrite pmulr_rgt0 // pmulrn_lgt0.
 - rewrite -(norm_scale_normalize (normalize (vaxis_euler M))) //.
   rewrite norm_normalize ?vaxis_euler_neq0 // w'axial //.
@@ -1426,8 +1444,8 @@ apply: (@same_isRot _ _ _ _ (- norm (Aa.vaxis M) *: w) ((sin (Aa.angle M) *+ 2) 
   by rewrite tr_axial scalerN.
 - by rewrite -a_angle_of_rot //.
 rewrite isRotZN; first by rewrite opprK isRot_eskew // normalizeI.
-  by rewrite -norm_eq0 w1 oner_neq0.
-by rewrite oppr_lt0 norm_gt0 // Aa.vaxis_neq0.
+  by rewrite -enorm_eq0 w1 oner_neq0.
+by rewrite oppr_lt0 enorm_gt0 // Aa.vaxis_neq0.
 Qed.
 
 Lemma angle_axis_isRot (Q : 'M[T]_3) : axial Q != 0 ->
@@ -1454,7 +1472,7 @@ rewrite {3}H isRotZ; last 2 first.
   rewrite invr_eq0 mulrn_eq0 /=.
     suff : 0 < sin (Aa.angle Q) by case: ltgtP.
     by apply: sin_gt0_pi.
-  by rewrite invr_gt0 norm_gt0.
+  by rewrite invr_gt0 enorm_gt0.
 exact: isRot_eskew_normalize.
 Qed.
 
@@ -1467,7 +1485,7 @@ Let vector := 'rV[T]_3.
 
 Record angle_axis := AngleAxis {
   angle_axis_val : T * vector ;
-  _ : norm (angle_axis_val.2) == 1 }.
+  _ : `|angle_axis_val.2|_e == 1 }.
 
 HB.instance Definition _ := [isSub for angle_axis_val].
 (*Canonical angle_axis_subType := [subType for angle_axis_val].*)
@@ -1475,20 +1493,20 @@ HB.instance Definition _ := [isSub for angle_axis_val].
 Definition aangle (a : angle_axis) := (val a).1.
 Definition aaxis (a : angle_axis) := (val a).2.
 
-Lemma norm_axis a : norm (aaxis a) = 1.
+Lemma enorm_axis a : `|aaxis a|_e = 1.
 Proof. by case: a => *; apply/eqP. Qed.
 
-Fact norm_e1_subproof : norm (@delta_mx T _ 3 0 0) == 1.
-Proof. by rewrite norm_delta_mx. Qed.
+Fact enorm_e1_subproof : `|@delta_mx T _ 3 0 0|_e == 1.
+Proof. by rewrite enorm_delta_mx. Qed.
 
 Definition angle_axis_of (a : T) (v : vector) :=
-  insubd (@AngleAxis (a,_) norm_e1_subproof) (a, normalize v).
+  insubd (@AngleAxis (a,_) enorm_e1_subproof) (a, normalize v).
 
 Lemma aaxis_of (a : T) (v : vector) : v != 0 ->
   aaxis (angle_axis_of a v) = normalize v.
 Proof.
 move=> v_neq0 /=; rewrite /angle_axis_of /aaxis val_insubd /=.
-by rewrite normZ normfV normr_norm mulVf ?norm_eq0 // eqxx.
+by rewrite enormZ normfV normr_enorm mulVf ?enorm_eq0// eqxx.
 Qed.
 
 Lemma aangle_of (a : T) (v : vector) : aangle (angle_axis_of a v) = a.
@@ -1520,35 +1538,35 @@ Hypothesis MO : M \is 'O[T]_3.
 
 Lemma sqr_Mi0E i : M i 1 ^+ 2 + M i 2%:R ^+ 2 = 1 - M i 0 ^+ 2.
 Proof.
-move/norm_row_of_O : MO => /(_ i)/(congr1 (fun x => x ^+ 2)).
+move/enorm_row_of_O : MO => /(_ i)/(congr1 (fun x => x ^+ 2)).
 rewrite -dotmulvv dotmulE sum3E !mxE -!expr2 expr1n => /eqP.
 by rewrite -addrA addrC eq_sym -subr_eq => /eqP <-.
 Qed.
 
 Lemma sqr_Mi1E i : M i 0 ^+ 2 + M i 2%:R ^+ 2 = 1 - M i 1 ^+ 2.
 Proof.
-move/norm_row_of_O : MO => /(_ i)/(congr1 (fun x => x ^+ 2)).
+move/enorm_row_of_O : MO => /(_ i)/(congr1 (fun x => x ^+ 2)).
 rewrite -dotmulvv dotmulE sum3E !mxE -!expr2 expr1n => /eqP.
 by rewrite addrAC eq_sym -subr_eq => /eqP <-.
 Qed.
 
 Lemma sqr_Mi2E i : M i 0 ^+ 2 + M i 1 ^+ 2 = 1 - M i 2%:R ^+ 2.
 Proof.
-move/norm_row_of_O : MO => /(_ i)/(congr1 (fun x => x ^+ 2)).
+move/enorm_row_of_O : MO => /(_ i)/(congr1 (fun x => x ^+ 2)).
 rewrite -dotmulvv dotmulE sum3E !mxE -!expr2 expr1n => /eqP.
 by rewrite eq_sym -subr_eq => /eqP <-.
 Qed.
 
 Lemma sqr_M2jE j : M 0 j ^+ 2 + M 1 j ^+ 2 = 1 - M 2%:R j ^+ 2.
 Proof.
-move/norm_col_of_O : MO => /(_ j)/(congr1 (fun x => x ^+ 2)).
+move/enorm_col_of_O : MO => /(_ j)/(congr1 (fun x => x ^+ 2)).
 rewrite -dotmulvv dotmulE sum3E !mxE -!expr2 expr1n => /eqP.
 by rewrite eq_sym -subr_eq => /eqP <-.
 Qed.
 
 Lemma sqr_M0jE j : M 1 j ^+ 2 + M 2%:R j ^+ 2 = 1 - M 0 j ^+ 2.
 Proof.
-move/norm_col_of_O : MO => /(_ j)/(congr1 (fun x => x ^+ 2)).
+move/enorm_col_of_O : MO => /(_ j)/(congr1 (fun x => x ^+ 2)).
 rewrite -dotmulvv dotmulE sum3E !mxE -!expr2 expr1n => /eqP.
 by rewrite -addrA addrC eq_sym -subr_eq => /eqP <-.
 Qed.
@@ -1601,7 +1619,7 @@ Local Open Scope frame_scope.
 
 (* two orthogonal vectors belonging to the plan (y,z) projected on y and z *)
 Lemma exists_rotation_angle (F : frame T) (u v : 'rV[T]_3) :
-  norm u = 1 -> norm v = 1 -> u *d v = 0 -> u *v v = F|,0 ->
+  `|u|_e = 1 -> `|v|_e = 1 -> u *d v = 0 -> u *v v = F|,0 ->
   { w : T | [/\ - pi < w <= pi,
             u = cos w *: (F|,1) + sin w *: (F|,2%:R) &
             v = - sin w *: (F|,1) + cos w *: (F|,2%:R)] }.
@@ -1626,7 +1644,7 @@ case/boolP : (u *d F|,2%:R == 0) => [/eqP|] u2.
   rewrite (orthogonal_expansion F u) (orthogonal_expansion F v).
   rewrite u2 u0 v0 v1 !(scale0r,addr0,add0r).
   have [/eqP u1 | /eqP u1] : {u *d F |, 1 == 1} + {u *d F|,1 == -1}.
-    move: normu => /(congr1 (fun x => x ^+ 2)); rewrite (sqr_norm_frame F u).
+    move: normu => /(congr1 (fun x => x ^+ 2)); rewrite (sqr_enorm_frame F u).
     rewrite sum3E u0 u2 expr0n add0r addr0 expr1n => /eqP.
     by rewrite sqrf_eq1 => /Bool.orb_true_elim.
   - have v2 : v *d F|,2%:R = 1.
@@ -1635,7 +1653,7 @@ case/boolP : (u *d F|,2%:R == 0) => [/eqP|] u2.
       rewrite {1}(orthogonal_expansion F v) v0 v1 !(scale0r,add0r).
       rewrite (linearZr_LR _ F|,1)/=.
       rewrite (frame_jcrossk F) => /scaler_eq1; apply.
-      by rewrite -norm_eq0 noframe_norm oner_eq0.
+      by rewrite -enorm_eq0 noframe_norm oner_eq0.
     rewrite v2 u1 !scale1r; by left.
   - have v2 : v *d F|,2%:R = -1.
       move: uva0.
@@ -1644,7 +1662,7 @@ case/boolP : (u *d F|,2%:R == 0) => [/eqP|] u2.
       rewrite (linearNl _ _ F|,1)/=.
       rewrite (linearZr_LR _ _ (v *d F|,2))/=.
       rewrite (frame_jcrossk F) -scaleNr => /scaler_eqN1; apply.
-      by rewrite -norm_eq0 noframe_norm oner_eq0.
+      by rewrite -enorm_eq0 noframe_norm oner_eq0.
     rewrite v2 u1 !scaleN1r; by right.
 have pi2B : - pi < (pi : T) / 2%:R <= pi.
   rewrite lter_pdivlMr ?ltr0n // ler_pdivrMr ?ltr0n //.
@@ -1657,7 +1675,7 @@ have piN2B : - pi < - ((pi : T) / 2%:R) <= pi.
 case/boolP : (u *d F|,1 == 0) => [/eqP|] u1.
   have {u2}[/eqP u2|/eqP u2] : {u *d F|,2%:R == 1} + {u *d F|,2%:R == -1}.
     move: normu => /(congr1 (fun x => x ^+ 2)).
-    rewrite (sqr_norm_frame F u) sum3E u0 u1 expr0n !add0r expr1n => /eqP.
+    rewrite (sqr_enorm_frame F u) sum3E u0 u1 expr0n !add0r expr1n => /eqP.
     by rewrite sqrf_eq1 => /Bool.orb_true_elim.
   + have v1 : v *d F|,1%:R = -1.
       move: uva0.
@@ -1666,10 +1684,10 @@ case/boolP : (u *d F|,1 == 0) => [/eqP|] u1.
       rewrite (linearDr _ F|,2)/=.
       rewrite (linearZr_LR _ _ (v *d F|,1)) /= (@lieC _ (vec3 T)) /= (frame_jcrossk F).
       rewrite (linearZr_LR _ _ (v *d F|,2)) /= (@liexx _ (vec3 T)) scaler0 addr0 scalerN -scaleNr => /scaler_eqN1; apply.
-      by rewrite -norm_eq0 noframe_norm oner_eq0.
+      by rewrite -enorm_eq0 noframe_norm oner_eq0.
     have v2 : v *d F|,2%:R = 0.
       move: normv => /(congr1 (fun x => x ^+ 2)).
-      rewrite expr1n (sqr_norm_frame F) sum3E v1 v0 expr0n add0r sqrrN expr1n => /eqP.
+      rewrite expr1n (sqr_enorm_frame F) sum3E v1 v0 expr0n add0r sqrrN expr1n => /eqP.
       by rewrite eq_sym addrC -subr_eq subrr eq_sym sqrf_eq0 => /eqP.
     exists (pi / 2%:R).
     rewrite cos_pihalf sin_pihalf !(scale0r,add0r,scale1r,scaleN1r,addr0).
@@ -1685,10 +1703,10 @@ case/boolP : (u *d F|,1 == 0) => [/eqP|] u1.
       rewrite (linearZr_LR _ _ (v *d F|,2))/=.
       rewrite /= (@liexx _ (vec3 T)) scaler0 subr0.
       rewrite -scalerN (@lieC _ (vec3 T)) /= opprK (frame_jcrossk F) => /scaler_eq1; apply.
-      by rewrite -norm_eq0 noframe_norm oner_eq0.
+      by rewrite -enorm_eq0 noframe_norm oner_eq0.
     have v2 : v *d F|,2%:R = 0.
       move: normv => /(congr1 (fun x => x ^+ 2)).
-      rewrite expr1n (sqr_norm_frame F) sum3E v1 v0 expr0n add0r expr1n => /eqP.
+      rewrite expr1n (sqr_enorm_frame F) sum3E v1 v0 expr0n add0r expr1n => /eqP.
       by rewrite eq_sym addrC -subr_eq subrr eq_sym sqrf_eq0 => /eqP.
     exists (- (pi / 2%:R)).
     rewrite cosN sinN cos_pihalf sin_pihalf ?(scale0r,add0r,scale1r,scaleN1r,addr0,opprK).
@@ -1703,10 +1721,10 @@ have f2D0 : F|,2%:R != 0 by apply: contra u2 => /eqP->; rewrite dotmulv0.
 have [w [wB Hw1 Hw2]] :
   {w : T | [/\ - pi < w <= pi, u *d F|,1 = cos w & (u *d F|,2%:R) = sin w]}.
   apply: sqrD1_cossin.
-  move/(congr1 (fun x => norm x)) : Hr2.
+  move/(congr1 (fun x => `|x|_e)) : Hr2.
   rewrite normu.
   move/(congr1 (fun x => x ^+ 2)).
-  rewrite expr1n normD !normZ ?noframe_norm !mulr1.
+  rewrite expr1n enormD !enormZ ?noframe_norm !mulr1.
   rewrite (_ : cos _ = 0); last first.
     case: (lerP 0 (u *d F|,2%:R)).
       rewrite le_eqVlt eq_sym (negbTE u2) /= => {}u2.
@@ -1760,16 +1778,16 @@ have <- : v *d F|,1 = - sin w.
   rewrite -Hw2 2!dotmul_cos normu 2!noframe_norm mul1r normv mulr1.
   rewrite [in LHS]mul1r [in RHS]mul1r ?opprK H'.
   rewrite [in RHS]cos_vec_anglevN ?opprK; [by [] | | ].
-  by rewrite -norm_eq0 normv oner_neq0.
-  by rewrite -norm_eq0 noframe_norm oner_neq0.
+  by rewrite -enorm_eq0 normv oner_neq0.
+  by rewrite -enorm_eq0 noframe_norm oner_neq0.
 have <- : v *d F|,2%:R = cos w.
   by rewrite -Hw1 2!dotmul_cos normu 2!noframe_norm mul1r normv mulr1 H.
 by [].
 Qed.
 
 Lemma euler_angles_zyx_RO (a1 a2 u v : 'rV[T]_3) w1 k k' :
-  norm u = 1 -> norm v = 1 -> u *d v = 0 ->
-  norm a1 = 1 -> norm a2 = 1 -> a1 *d a2 = 0 ->
+  `|u|_e = 1 -> `|v|_e = 1 -> u *d v = 0 ->
+  `|a1|_e = 1 -> `|a2|_e = 1 -> a1 *d a2 = 0 ->
   u = k *: a1 + k' *: a2 ->
   v = - k' *: a1 + k *: a2 ->
   cos w1 = a1 *d u ->
@@ -1853,8 +1871,8 @@ transitivity (row_mx (col 0 R) (row_mx a2 a3) *m Rx w1).
                  r2^T = cos w *: (a |, 1) + sin w *: (a |, 2%:R) &
                  r3^T = - sin w *: (a |, 1) + cos w *: (a |, 2%:R)] }.
       apply: exists_rotation_angle.
-      by rewrite tr_col norm_row_of_O // rotation_sub // rotationV.
-      by rewrite tr_col norm_row_of_O // rotation_sub // rotationV.
+      by rewrite tr_col enorm_row_of_O// rotation_sub// rotationV.
+      by rewrite tr_col enorm_row_of_O// rotation_sub// rotationV.
       rewrite 2!tr_col.
       by move: RSO; rewrite -rotationV => /rotation_sub/orthogonalP ->.
       rewrite frame_of_SO_i -tr_col -/a1 Ha1 !tr_col.
@@ -1877,8 +1895,8 @@ transitivity (row_mx (col 0 R) (row_mx a2 a3) *m Rx w1).
   by move: RSO; rewrite -rotationV => /rotation_sub/orthogonal3P/and6P[_ /eqP].
   by move: RSO; rewrite -rotationV => /rotation_sub/orthogonal3P/and6P[_ _ /eqP].
   move: RSO; by rewrite -rotationV => /rotation_sub/orthogonal3P/and6P[_ _ _ _ _ /eqP].
-  by rewrite tr_col norm_row_of_O // rotation_sub // rotationV Rzy_is_SO.
-  by rewrite tr_col norm_row_of_O // rotation_sub // rotationV Rzy_is_SO.
+  by rewrite tr_col enorm_row_of_O// rotation_sub// rotationV Rzy_is_SO.
+  by rewrite tr_col enorm_row_of_O// rotation_sub// rotationV Rzy_is_SO.
   move: (Rzy_is_SO w3 w2).
   rewrite -rotationV => /rotation_sub/orthogonal3P/and6P[_ _ _ _ _ /eqP].
   by rewrite !tr_col.
@@ -1887,14 +1905,14 @@ transitivity (row_mx (col 0 R) (row_mx a2 a3) *m Rx w1).
 by rewrite -Ha1 row_mx_colE.
 Qed.
 
-Lemma Rz_rotation_exists (u : 'rV[T]_3) : norm u = 1 ->
+Lemma Rz_rotation_exists (u : 'rV[T]_3) : `|u|_e = 1 ->
   u != 'e_2%:R -> u != - 'e_2%:R ->
   let n : 'rV_3 := normalize ('e_2%:R *v u) in
   {phi | isRot phi 'e_2%:R (mx_lin1 (Rz phi)) & 'e_0 *m Rz phi = n}.
 Proof.
 move=> u1 H1 H2 n.
 exists (if 0 <= u``_0 then vec_angle n 'e_0 else - vec_angle n 'e_0).
-  by rewrite Rz_eskew isRot_eskew // ?normalizeI // ?norm_delta_mx.
+  by rewrite Rz_eskew isRot_eskew ?normalizeI ?enorm_delta_mx.
 rewrite {1}e0row /Rz mulmx_row3_col3 ?(scale0r,scale1r,addr0).
 rewrite [in RHS]/n crossmulE.
 rewrite (_ : 'e_2%:R 0 1 = 0) ?(mul0r,add0r); last by rewrite mxE.
@@ -1902,9 +1920,9 @@ rewrite (_ : 'e_2%:R 0 0 = 0) ?(mul0r,subrr,subr0); last by rewrite mxE.
 rewrite (_ : 'e_2%:R 0 2%:R = 1) ?mul1r; last by rewrite mxE.
 have ? : 'e_2%:R *v u != 0.
   apply/colinearP; case.
-    by rewrite -norm_eq0 u1 // oner_eq0.
+    by rewrite -enorm_eq0 u1 // oner_eq0.
   case=> _ [k Hk]; have k1 : `|k| = 1.
-    move: Hk => /(congr1 (@norm _ _)); rewrite normZ u1 mulr1 norm_delta_mx.
+    move: Hk => /(congr1 (@enorm _ _)); rewrite enormZ u1 mulr1 enorm_delta_mx.
     by move->.
   case: (lerP k 0) => k0; move: k1 Hk.
     rewrite ler0_norm // -{2}(opprK k) => ->; rewrite scaleN1r.
@@ -1912,13 +1930,13 @@ have ? : 'e_2%:R *v u != 0.
   by rewrite gtr0_norm // => ->; rewrite scale1r => /esym; apply/eqP.
 rewrite /normalize row3Z mulr0; congr row3.
 - transitivity (n *d 'e_0).
-    rewrite dotmul_cos norm_normalize ?mul1r ?norm_delta_mx ?mul1r //.
+    rewrite dotmul_cos norm_normalize ?mul1r ?enorm_delta_mx ?mul1r //.
     case: ifP => //; by rewrite cosN.
   by rewrite -coorE /n crossmulE /normalize row3Z !mxE /= ?(mulr0,mul0r,add0r,mul1r,subr0,oppr0).
-- transitivity (if 0 <= u``_0 then norm (n *v 'e_0) else - norm (n *v 'e_0)).
-    rewrite norm_crossmul norm_normalize ?mul1r // norm_delta_mx mul1r.
-    rewrite ger0_norm // ?sin_vec_angle_ge0 // -?norm_eq0 ?norm_normalize ?oner_neq0 //
-      ?norm_delta_mx ?oner_neq0 //.
+- transitivity (if 0 <= u``_0 then `|n *v 'e_0|_e else - `|n *v 'e_0|_e).
+    rewrite enorm_crossmul norm_normalize ?mul1r // enorm_delta_mx mul1r.
+    rewrite ger0_norm // ?sin_vec_angle_ge0 // -?enorm_eq0 ?norm_normalize ?oner_neq0 //
+      ?enorm_delta_mx ?oner_neq0 //.
     case: ifPn => //; by rewrite sinN.
   rewrite /n /normalize crossmulE.
   rewrite (_ : 'e_0%:R 0 2%:R = 0) ?(mulr0,subr0,add0r); last by rewrite mxE.
@@ -1929,12 +1947,12 @@ rewrite /normalize row3Z mulr0; congr row3.
   rewrite (_ : 'e_2%:R 0 0 = 0) ?(mul0r,subrr,subr0); last by rewrite mxE.
   rewrite (_ : 'e_2%:R 0 2%:R = 1) ?(mul1r); last by rewrite mxE.
   rewrite !mxE mulr0 /=.
-  rewrite -{2 3 5 6}(oppr0) -row3N normN.
+  rewrite -{2 3 5 6}(oppr0) -row3N enormN.
   rewrite [in LHS]mulrC -{2 3 5 6}(mulr0 (u``_0)) -row3Z.
-  rewrite normZ mulrC norm_row3z ger0_norm ?invr_ge0 ?norm_ge0 //.
+  rewrite enormZ mulrC enorm_row3z ger0_norm ?invr_ge0 ?enorm_ge0//.
   case: ifPn => R20.
   - by rewrite ger0_norm.
-  - by rewrite ltr0_norm ?ltNge // mulrN opprK.
+  - by rewrite ltr0_norm ?ltNge// mulrN opprK.
 Qed.
 
 End euler_angles_existence.

--- a/scara.v
+++ b/scara.v
@@ -1,5 +1,5 @@
-(* coq-robot (c) 2017 AIST and INRIA. License: LGPL-2.1-or-later. *)
-From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum rat poly.
+(* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
+From mathcomp Require Import all_boot ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import realalg complex fingroup perm.
 From mathcomp Require Import sesquilinear.
@@ -8,18 +8,20 @@ Require Import ssr_ext euclidean skew vec_angle rot frame rigid screw.
 From mathcomp Require Import reals.
 Require Import extra_trigo.
 
-(******************************************************************************)
-(*                        SCARA Robot Manipulator                             *)
+(**md**************************************************************************)
+(* # SCARA Robot Manipulator                                                  *)
 (*                                                                            *)
 (* This file addresses the forward kinematics problem for the SCARA robot     *)
 (* manipulator in two ways: (1) it first provides the DH parameters,          *)
 (* (2) using screw motions.                                                   *)
 (*                                                                            *)
+(* ```                                                                        *)
 (* B10,B21,B32,B43 == relative positions of the consecutive frames of the     *)
 (*                    SCARA robot manipulator using DH parameters             *)
 (*     t1,t2,t3,t4 == twists of the SCARA robot manipulator                   *)
 (*              g0 == position of the end-effector using twists               *)
 (*               g == orientation of the end-effector using twists            *)
+(* ```                                                                        *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -118,7 +120,7 @@ rewrite /t1 /rjoint_twist.
 rewrite (linearNl _ q1)/=.
 rewrite (linear0r _ w1)/=.
 rewrite oppr0 etwist_Rz; last first.
-  by rewrite -norm_eq0 normeE oner_eq0.
+  by rewrite -enorm_eq0 enormeE oner_eq0.
 by rewrite -Rz_eskew.
 Qed.
 
@@ -126,11 +128,11 @@ Qed.
 Lemma point_axis_twist (d : R) :
   \pt( axis \T((- 'e_2%:R *v row3 d 0 0), 'e_2%:R) ) = row3 d 0 0.
 Proof.
-rewrite {1}/axis ang_tcoorE (negbTE (norm1_neq0 (normeE _ _))) /=.
-rewrite normeE expr1n invr1 scale1r lin_tcoorE.
+rewrite {1}/axis ang_tcoorE (negbTE (norm1_neq0 (enormeE _ _))) /=.
+rewrite enormeE expr1n invr1 scale1r lin_tcoorE.
 rewrite (linearNl _ ((row3 d)``_0))/=.
 rewrite (linearNr _ ('e_2))/=.
-rewrite double_crossmul dotmulvv normeE expr1n scale1r /w2 /q2 e2row.
+rewrite double_crossmul dotmulvv enormeE expr1n scale1r /w2 /q2 e2row.
 rewrite dotmulE sum3E !mxE /=. by Simp.r.
 Qed.
 
@@ -138,8 +140,8 @@ Lemma S2_helper th d :
   `e$(th, \T(- w2 *v row3 d 0 0, w2)) =
   hom (Rz th) (row3 (d * (1 - cos th)) (- d * sin th) 0).
 Proof.
-rewrite etwistE (negbTE (norm1_neq0 (normeE _ _))).
-rewrite pitch_perp ?normeE // mulr0 scale0r add0r.
+rewrite etwistE (negbTE (norm1_neq0 (enormeE _ _))).
+rewrite pitch_perp ?enormeE// mulr0 scale0r add0r.
 rewrite point_axis_twist -Rz_eskew; congr hom.
 rewrite mulmxBr mulmx1 mulmx_row3_col3 !scale0r !addr0 row3Z row3N row3D.
 Simp.r.

--- a/screw.v
+++ b/screw.v
@@ -1,4 +1,4 @@
-(* coq-robot (c) 2017 AIST and INRIA. License: LGPL-2.1-or-later. *)
+(* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From HB Require Import structures.
 From mathcomp Require Import all_boot order ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
@@ -7,8 +7,8 @@ From mathcomp Require Import sesquilinear.
 From mathcomp Require Import interval reals trigo.
 Require Import ssr_ext euclidean skew vec_angle frame rot rigid extra_trigo.
 
-(******************************************************************************)
-(*                             Screw Motions                                  *)
+(**md**************************************************************************)
+(* # Screw Motions                                                            *)
 (*                                                                            *)
 (* This file develops the theory of screws and twists. It establishes in      *)
 (* particular Chasles' theorem (given a rigid body motion, it shows           *)
@@ -16,6 +16,7 @@ Require Import ssr_ext euclidean skew vec_angle frame rot rigid extra_trigo.
 (* rigid body motion), Mozzi-Chasles' theorem (it shows the existence of a    *)
 (* set of points that undergo just a translation---this is the screw axis).   *)
 (*                                                                            *)
+(* ```                                                                        *)
 (* Module sqLieAlgebra == square matrices form a Lie algebra                  *)
 (*   'se3[R] == the set of twists                                             *)
 (*   wedge t == form a twist in 'se3[R] given twist (coordinates)             *)
@@ -35,6 +36,7 @@ Require Import ssr_ext euclidean skew vec_angle frame rot rigid extra_trigo.
 (* `e$(a, t) == the exponential of a twist t with angle a                     *)
 (* rjoint_twist w p == twist of a revolute joint                              *)
 (* pjoint_twist v == twist of a prismatic joint                               *)
+(* ```                                                                        *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -54,7 +56,7 @@ Local Open Scope ring_scope.
 
 (* TODO: move? *)
 Lemma mulmx_tr_uvect (T : rcfType) (w : 'rV[T]_3) :
-  norm w = 1 -> (w^T *m w) ^+ 2 = w^T *m w.
+  `|w|_e = 1 -> (w^T *m w) ^+ 2 = w^T *m w.
 Proof.
 move=> w1; rewrite expr2 -mulmxE -mulmxA (mulmxA w) dotmulP dotmulvv w1 expr1n.
 by rewrite mul1mx.
@@ -623,7 +625,7 @@ rewrite /wedge Twist.ang_of Twist.lin_of spin0.
 by rewrite -idmxE (@scalar_mx_block _ 3 1 1) (add_block_mx 1 0 0 1 0 _ v) !(addr0,add0r).
 Qed.
 
-Lemma p41eq234 w v : norm w = 1 ->
+Lemma p41eq234 w v : `|w|_e = 1 ->
   let g := rigid_trans w v in
   let h := w *d v in
   g^-1 *m wedge \T(v, w) *m g = wedge \T(h *: w, w).
@@ -651,7 +653,7 @@ rewrite !mulrA divrr ?rigid_trans_unit // mul1r -mulrA.
 by rewrite divrr ?mulr1 // rigid_trans_unit.
 Qed.
 
-Lemma p42eq2 w v : norm w = 1 ->
+Lemma p42eq2 w v : `|w|_e = 1 ->
   let g := rigid_trans w v in
   let e' := g^-1 *m wedge \T(v, w) *m g in
   forall k, e' ^+ k.+2 = block_mx (\S( w ) ^+ k.+2) 0 0 0.
@@ -671,7 +673,7 @@ rewrite exprS mulmxA spinE.
 by rewrite (linearZr_LR _ w)/= (@liexx _ (vec3 T)) scaler0 mul0mx.
 Qed.
 
-Lemma emx2_twist w v a : norm w = 1 ->
+Lemma emx2_twist w v a : `|w|_e = 1 ->
   let g := rigid_trans w v in
   let h := w *d v in
   emx (a *: wedge \T(v, w) ) 2 = g *m hom (emx (a *: \S( w)) 2) (h *: (a *: w)) *m g^-1.
@@ -694,7 +696,7 @@ rewrite (linearZl_LR _ (v *v w))/= -scalerDr; congr (_ *: _).
 by rewrite double_crossmul dotmulvv w1 expr1n scale1r -/h addrCA subrr addr0.
 Qed.
 
-Lemma p42eq3 w v a : norm w = 1 ->
+Lemma p42eq3 w v a : `|w|_e = 1 ->
   let g := rigid_trans w v in
   let h := w *d v in
   let e' := g^-1 *m wedge \T(v, w) *m g in
@@ -718,7 +720,7 @@ Definition hom_twist (t : twist T) (a : T) e : 'M[T]_4 :=
   if w == 0 then
     hom 1 (a *: v)
   else
-    hom e ((norm w)^-2 *: ((w *v v) *m (1 - e) + (a *: v) *m (w^T *m w))).
+    hom e ((`|w|_e) ^- 2 *: ((w *v v) *m (1 - e) + (a *: v) *m (w^T *m w))).
 
 (* [murray] eqn 2.36, p.42 *)
 Definition emx_twist a t k : 'M_4 :=
@@ -736,9 +738,9 @@ case/boolP : (w == 0) => [/eqP ->|w0].
   rewrite tcoorZ /= scaler0 emx_twist0E.
   by rewrite /emx_twist /hom_twist ang_tcoorE eqxx lin_tcoorE.
 set w' : 'rV_3 := a *: w.
-rewrite -(norm_scale_normalize w) (_ : v = (norm w) *: ((norm w)^-1 *: v)); last first.
-  by rewrite scalerA divrr ?scale1r // unitfE norm_eq0.
-rewrite -(tcoorZ (norm w) ((norm w)^-1 *: v) (normalize w)).
+rewrite -(norm_scale_normalize w) (_ : v = `|w|_e *: ((`|w|_e)^-1 *: v)); last first.
+  by rewrite scalerA divrr ?scale1r // unitfE enorm_eq0.
+rewrite -(tcoorZ `|w|_e ((`|w|_e)^-1 *: v) (normalize w)).
 rewrite scalerA p42eq235 p42eq3; last by rewrite norm_normalize.
 rewrite -mulmxE.
 rewrite {1}/rigid_trans mulmxE homM mul1r.
@@ -760,19 +762,19 @@ rewrite (linearZl_LR _ w) /=.
 rewrite [in X in _ + _ + X = _]scalerN.
 rewrite [in X in _ + _ + X]scalerA.
 rewrite -[in LHS]scalemxAl -scalerDr -scalerBr; congr (_ *: _).
-  by rewrite -invrM ?unitfE ?norm_eq0.
+  by rewrite -invrM ?unitfE ?enorm_eq0.
 rewrite -/w' /= [in X in _ = X + _]mulmxBr mulmx1.
 rewrite -[in RHS]addrA [in RHS]addrC; congr (_ + _ + _).
 - rewrite lin_tcoorE (@lieC _ (vec3 T)) mulNmx.
-  by rewrite scalerA divrr ?scale1r // ?unitfE ?norm_eq0.
+  by rewrite scalerA divrr ?scale1r ?unitfE ?enorm_eq0.
 - rewrite lin_tcoorE.
-  rewrite (scalerA (norm w)) divrr ?scale1r ?unitfE ?norm_eq0 //.
+  rewrite (scalerA `|w|_e) divrr ?scale1r ?unitfE ?enorm_eq0//.
   rewrite -scalemxAl.
   rewrite mulmxA.
   rewrite dotmulP mul_scalar_mx dotmulC.
   by rewrite scalerA mulrC -scalerA.
 - rewrite (@lieC _ (vec3 T)) opprK; congr (_ *v _).
-  by rewrite lin_tcoorE scalerA divrr ?scale1r ?lin_of_twistE // unitfE norm_eq0.
+  by rewrite lin_tcoorE scalerA divrr ?scale1r ?lin_of_twistE // unitfE enorm_eq0.
 Qed.
 
 (* [murray] proposition 2.8, p. 41 *)
@@ -803,16 +805,16 @@ Local Notation "'`e$(' a ',' t ')'" := (etwist a t) (format "'`e$(' a ','  t ')'
 Lemma etwistv0 (a : T) : `e$(a, \T(0, 0)) = hom 1 0.
 Proof. by rewrite /etwist ang_tcoorE /hom_twist ang_tcoorE eqxx lin_tcoorE scaler0. Qed.
 
-Lemma etwist_is_SE (t : twist T) a : norm \w( t ) = 1 -> `e$(a, t) \is 'SE3[T].
+Lemma etwist_is_SE (t : twist T) a : `|\w( t )|_e = 1 -> `e$(a, t) \is 'SE3[T].
 Proof.
 move=> w1.
 by rewrite /etwist /hom_twist (negbTE (norm1_neq0 w1)) hom_is_SE // eskew_is_SO.
 Qed.
 
 Definition etwist_is_onto_SE_mat (a : T) w :=
-  (a * norm w ^+ 2)%:A
-    + ((1 - cos a) * norm w ^+2) *: \S(w)
-      + (a - sin a) *: \S(w)^+2.
+  (a * `|w|_e ^+ 2)%:A
+    + ((1 - cos a) * `|w|_e ^+ 2) *: \S(w)
+      + (a - sin a) *: \S(w) ^+ 2.
 
 (*******************STOP*****************************)
 Definition etwist_is_onto_SE_mat_inv (a : T) w :=
@@ -820,8 +822,8 @@ Definition etwist_is_onto_SE_mat_inv (a : T) w :=
    - 2%:R^-1 *: \S(w)
      + (a^-1 - 2%:R^-1 * cot (a / 2%:R)) *: \S(w) ^+ 2.
 
-Lemma etwist_is_onto_SE_matP a w 
-  (aB : - pi < a <= pi) (a0 : a != 0) (w1 : norm w = 1) :
+Lemma etwist_is_onto_SE_matP a w
+  (aB : - pi < a <= pi) (a0 : a != 0) (w1 : `|w|_e = 1) :
   etwist_is_onto_SE_mat_inv a w * etwist_is_onto_SE_mat a w = 1.
 Proof.
 rewrite /etwist_is_onto_SE_mat /etwist_is_onto_SE_mat_inv.
@@ -901,11 +903,11 @@ Lemma etwist_is_onto_SE (f : 'M[T]_4) : f \is 'SE3[T] ->
 Proof.
 set p := trans_of_hom f.
 case/boolP: (rot_of_hom f == 1) => rotf fSE.
-case/boolP : ((norm p) == 0) => p0.
+case/boolP : (`|p|_e == 0) => p0.
     exists \T(p, 0), 1.
     rewrite /etwist /hom_twist ang_tcoorE eqxx lin_tcoorE.
     by rewrite scale1r (SE3E fSE) (eqP rotf).
-  exists \T((norm p)^-1 *: p, 0), (norm p).
+  exists \T((`|p|_e)^-1 *: p, 0), `|p|_e.
   rewrite /etwist /hom_twist ang_tcoorE eqxx /= lin_tcoorE.
   rewrite scalerA divff //.
   by rewrite scale1r (SE3E fSE) (eqP rotf).
@@ -915,7 +917,7 @@ have a0 : a != 0.
   apply: contra rotf => /eqP.
   rewrite fexp_skew => ->; by rewrite emx30M.
 set A : 'M_3 := \S(w) *m (1 - rot_of_hom f) + a *: (w^T *m w).
-suff [v Hv] : { v | p = (norm w)^-2 *: (v *m A) }.
+suff [v Hv] : { v | p = (`|w|_e) ^- 2 *: (v *m A) }.
   exists \T(v, w), a.
   rewrite (SE3E fSE) /etwist /hom_twist ang_tcoorE.
   have /negbTE -> : w != 0 by rewrite normalize_eq0 vaxis_euler_neq0 // rot_of_hom_is_SO.
@@ -942,9 +944,9 @@ have HA : A = etwist_is_onto_SE_mat a w.
   by rewrite scaleNr scalerN opprK scalerA.
 suff : { A' : 'M_3 |  A' * A = 1 }.
   case => A' AA'.
-  exists ((norm w) ^+2 *: p *m A').
+  exists ((`|w|_e) ^+ 2 *: p *m A').
   rewrite -mulmxA mulmxE AA' mulmx1 scalerA.
-  rewrite mulrC divrr ?scale1r // unitfE expf_eq0 /= norm_eq0.
+  rewrite mulrC divrr ?scale1r // unitfE expf_eq0 /= enorm_eq0.
   apply: contra rotf; rewrite fexp_skew => /eqP ->.
   by rewrite spin0 emx3a0.
 (* NB: corresponds to [murray], exercise 9, p.75 *)
@@ -989,11 +991,11 @@ Definition w : vector := 'e_2%:R.
 
 Let A_inv := etwist_is_onto_SE_mat_inv a w.
 
-Definition v := ((norm w)^+2 *: P20) *m A_inv.
+Definition v := ((`|w|_e) ^+ 2 *: P20) *m A_inv.
 
 Lemma vP : v = row3 ((a1 + a2) * sin a / (2%:R * (1 - cos a))) (- (a1 - a2) / 2%:R) 0 :> vector.
 Proof.
-rewrite /v normeE expr1n scale1r /P20.
+rewrite /v enormeE expr1n scale1r /P20.
 rewrite /A_inv /etwist_is_onto_SE_mat_inv.
 rewrite mulmxDr mulmxBr.
 rewrite mul_mx_scalar row3Z mulr0.
@@ -1053,7 +1055,7 @@ Definition screw_motion s (p : point) : 'rV_3 :=
   let p0 := \pt( l ) in let w := \vec( l ) in
   p0 + (p - p0) *m `e^(a, w) + (h * a) *: w.
 
-Lemma screw_motionE s (p : point) (w1 : norm \vec( Screw.l s) = 1) :
+Lemma screw_motionE s (p : point) (w1 : `| \vec( Screw.l s) |_e = 1) :
   let l := Screw.l s in let a := Screw.a s in let h := Screw.h s in
   let q := \pt( l ) in let w := \vec( l ) in
   screw_motion s p = EuclideanMotion.motion_point
@@ -1114,7 +1116,7 @@ rewrite [in X in _ = _ *: (X + _)]mulmxBl.
 rewrite opprB -addrA.
 rewrite scalerDr.
 rewrite -[in X in _ = X + _]scalemxAl scalerA [in X in _ = X + _]mulrC divrr ?scale1r; last first.
-  by rewrite unitfE expf_eq0 /= norm_eq0.
+  by rewrite unitfE expf_eq0 /= enorm_eq0.
 congr (_ + _).
 rewrite -[in X in _ = _ *: (_ + X)]scalemxAl.
 rewrite mulmxDl.
@@ -1125,7 +1127,7 @@ rewrite scalerDr.
 rewrite 2!scalerA.
 rewrite [in X in _ = X + _]mulrA.
 rewrite [in X in _ = X + _]mulrC.
-rewrite -(mulrA (a * h)) divrr ?mulr1; last by rewrite unitfE expf_eq0 /= norm_eq0.
+rewrite -(mulrA (a * h)) divrr ?mulr1; last by rewrite unitfE expf_eq0 /= enorm_eq0.
 rewrite mulrC -[LHS]addr0.
 congr (_ + _).
 rewrite mulmxBr mulmx1.
@@ -1154,7 +1156,7 @@ Definition axis (t : twist T) : Line.t T :=
   if w == 0 then
     Line.mk 0 v
   else
-    Line.mk ((norm w)^-2 *: (w *v v)) w.
+    Line.mk ((`|w|_e) ^- 2 *: (w *v v)) w.
 
 Lemma point_axis_nolin w : w != 0 -> \pt( axis \T(0, w) ) = 0.
 Proof.
@@ -1165,7 +1167,7 @@ Qed.
 (* [murray] 2.42, p.47 *)
 Definition pitch (t : twist T) : T :=
   let w := \w( t ) in let v := \v( t ) in
-  (norm w)^-2 *: v *d w.
+  (`|w|_e) ^- 2 *: v *d w.
 
 Lemma pitch_nolin (w : 'rV[T]_3) : pitch \T(0, w) = 0.
 Proof. by rewrite /pitch ang_tcoorE lin_tcoorE scaler0 dotmul0v. Qed.
@@ -1174,7 +1176,7 @@ Definition rjoint_twist (w : vector) (q : point) := \T(- w *v q, w).
 
 Definition pjoint_twist (v : vector) := \T(v, 0).
 
-Lemma pitch_perp (w u : 'rV[T]_3) : norm w = 1 -> pitch (rjoint_twist w u) = 0.
+Lemma pitch_perp (w u : 'rV[T]_3) : `|w|_e = 1 -> pitch (rjoint_twist w u) = 0.
 Proof.
 move=> w1; rewrite /pitch ang_tcoorE lin_tcoorE w1 expr1n invr1 scale1r.
 rewrite (@lieC _ (vec3 T))/=.
@@ -1184,34 +1186,34 @@ Qed.
 (* [murray] 2.44, p.48 *)
 Definition magnitude (t : twist T) : T :=
   let w := \w( t ) in let v := \v( t ) in
-  if w == 0 then norm v else norm w.
+  if w == 0 then `|v|_e else `|w|_e.
 
 Lemma magnitudeZ (t : twist T) a : 0 < a ->
   magnitude ((a *: t) : 'M__) = a * magnitude t.
 Proof.
 move=> a_gt0.
 rewrite /magnitude.
-case/boolP : (a == 0) => [/eqP ->|a0].
-  by rewrite scale0r mul0r ang_tcoor0 eqxx lin_tcoor0 norm0.
+have [->|a0] := eqVneq a 0.
+  by rewrite scale0r mul0r ang_tcoor0 eqxx lin_tcoor0 enorm0.
 rewrite ang_tcoorZ scaler_eq0 (negbTE a0) /=.
 case: ifPn => M0.
-  by rewrite lin_tcoorZ normZ gtr0_norm.
-by rewrite normZ gtr0_norm.
+  by rewrite lin_tcoorZ enormZ gtr0_norm.
+by rewrite enormZ gtr0_norm.
 Qed.
 
 (* unit twist: [murray] p.49 (p.48 also) *)
 Definition utwist (t : twist T) := (magnitude t == 1).
 
 Lemma utwistE (t : twist T) : utwist t =
-  (norm \w( t ) == 1) || ((norm \w( t ) == 0) && (norm \v( t ) == 1)).
+  (`| \w( t ) |_e == 1) || ((`| \w( t ) |_e == 0) && (`| \v( t ) |_e == 1)).
 Proof.
 apply/idP/idP.
 - rewrite /utwist /magnitude.
-  case: ifPn => [/eqP -> ->|w0 ->]; by rewrite norm_eq0 ?eqxx /= ?orbT.
+  case: ifPn => [/eqP -> ->|w0 ->]; by rewrite enorm_eq0 ?eqxx /= ?orbT.
 - case/orP => [w1|/andP[w0 v1]].
     rewrite /utwist /magnitude; case: ifPn => [w0| //].
-    by rewrite (eqP w0) norm0 eq_sym (negbTE (@oner_neq0 _)) in w1.
-  by rewrite /utwist /magnitude -{1}norm_eq0 w0.
+    by rewrite (eqP w0) enorm0 eq_sym (negbTE (@oner_neq0 _)) in w1.
+  by rewrite /utwist /magnitude -{1}enorm_eq0 w0.
 Qed.
 
 (* [murray] p. 48
@@ -1279,7 +1281,7 @@ congr hom.
 rewrite lin_tcoorE.
 rewrite -scalemxAl mulmxA dotmulP scalemxAl scalerDr -scalemxAl.
 rewrite (scalerA _ a) (mulrC _ a).
-rewrite -(scalerA a (norm w ^+ 2)^-1).
+rewrite -(scalerA a (`|w|_e ^+ 2)^-1).
 rewrite mul_scalar_mx (scalerA _ (v *d w) w) -(dotmulZv v _ w).
 rewrite (_ : _ *d _ = pitch \T(v, w)); last by rewrite /pitch lin_tcoorE ang_tcoorE.
 rewrite addrC.
@@ -1320,7 +1322,7 @@ Let vaxis0 : Aa.vaxis Q != 0.
 Proof.
 by rewrite /Aa.vaxis (negbTE api) scaler_eq0 negb_or w0 andbT invr_eq0 mulrn_eq0.
 Qed.
-Let w1 : norm w = 1. Proof. by rewrite norm_normalize. Qed.
+Let w1 : `|w|_e = 1. Proof. by rewrite norm_normalize. Qed.
 
 (* [angeles] theorem 3.2.1, p.97:
    the displacements of all the points of the body have the same projection onto e *)
@@ -1341,32 +1343,32 @@ Qed.
 
 Definition axialdisp p := axialcomp (displacement f p) w.
 
-Lemma axialdispE p : axialdisp p = d0 *: ((norm w)^-2 *: w).
+Lemma axialdispE p : axialdisp p = d0 *: ((`|w|_e) ^- 2 *: w).
 Proof.
 rewrite /axialdisp /axialcomp dotmulC dotmulvZ displacement_proj mulrC -scalerA.
-by rewrite (scalerA (norm w)^-1) -expr2 exprVn.
+by rewrite (scalerA (`|w|_e)^-1) -expr2 exprVn.
 Qed.
 
 Definition normdisp p := normalcomp (displacement f p) w.
 
 Lemma decomp_displacement p :
-  norm (displacement f p) ^+ 2 = norm (d0 *: (norm w ^- 2 *: w)) ^+2 + norm (normdisp p) ^+ 2.
+  `|displacement f p|_e ^+ 2 = `|d0 *: (`|w|_e ^- 2 *: w)|_e ^+2 + `|normdisp p|_e ^+ 2.
 Proof.
-rewrite (axialnormalcomp (displacement f p) w) normD -dotmul_cos axialnormal // mul0rn addr0.
+rewrite (axialnormalcomp (displacement f p) w) enormD -dotmul_cos axialnormal // mul0rn addr0.
 by rewrite -/(normdisp p) -/(axialdisp p) axialdispE.
 Qed.
 
-Lemma MozziChasles_helper p : norm (displacement f p) = d0 -> normdisp p = 0.
+Lemma MozziChasles_helper p : `|displacement f p|_e = d0 -> normdisp p = 0.
 Proof.
 move=> Hp.
-have := lexx (norm (d0 *: w) ^+ 2).
-rewrite {1}normZ w1 mulr1 sqr_normr -{1}Hp decomp_displacement -lerBDl.
+have := lexx (`|d0 *: w|_e ^+ 2).
+rewrite {1}enormZ w1 mulr1 sqr_normr -{1}Hp decomp_displacement -lerBDl.
 rewrite w1 expr1n invr1 scale1r.
-by rewrite subrr le_eqVlt ltNge sqr_ge0 orbF sqrf_eq0 norm_eq0 => /eqP.
+by rewrite subrr le_eqVlt ltNge sqr_ge0 orbF sqrf_eq0 enorm_eq0 => /eqP.
 Qed.
 
 (* [angeles] theorem 3.2.2, p.97 *)
-Lemma MozziChasles p : norm (displacement f p) = d0 ->
+Lemma MozziChasles p : `|displacement f p|_e = d0 ->
   colinear (displacement f p) w.
 Proof.
 move=> H.
@@ -1443,8 +1445,8 @@ rewrite /Aa.vaxis.
 rewrite (negbTE api).
 by rewrite scaler_eq0 negb_or w0 andbT invr_eq0 mulrn_eq0.
 Qed.
-Let w1 : norm w = 1.
-Proof. rewrite norm_normalize //. Qed.
+Let w1 : `|w|_e = 1.
+Proof. by rewrite norm_normalize. Qed.
 
 Lemma wTwQN1 : (w^T *m w) *m (Q - 1)^T = 0.
 Proof.
@@ -1580,7 +1582,7 @@ Qed.
 (* [angeles] Sect. 3.2.1 (the screw of a rigid-body motion) *)
 Lemma screw_axis_pointE p0 q :
   p0 *d w = 0 (* p0 is the closed point to the origin *) ->
-  norm (displacement f p0) = d0 f ->
+  `|displacement f p0|_e = d0 f ->
   p0 = screw_axis_point f q.
 Proof.
 move=> p0e0 fp0e0.

--- a/skew.v
+++ b/skew.v
@@ -1,18 +1,19 @@
-(* coq-robot (c) 2017 AIST and INRIA. License: LGPL-2.1-or-later. *)
+(* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From HB Require Import structures.
-From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum rat poly.
+From mathcomp Require Import all_boot ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import sesquilinear.
 From mathcomp Require Import realalg complex finset fingroup perm ring.
 Require Import ssr_ext euclidean vec_angle.
 From mathcomp Require Import reals.
 
-(******************************************************************************)
-(*                         Skew-symmetric matrices                            *)
+(**md**************************************************************************)
+(* # Skew-symmetric matrices                                                  *)
 (*                                                                            *)
 (* This file develops the theory of skew-symmetric matrices to be used in     *)
 (* particular to represent the exponential coordinates of rotation matrices.  *)
 (*                                                                            *)
+(* ```                                                                        *)
 (* 'so[R]_n == the type of skew-symmetric matrices, i.e., matrices M such     *)
 (*              that M = -M^T                                                 *)
 (*    \S(w) == the spin of vector w, i.e., the (row-vector convention)        *)
@@ -20,10 +21,13 @@ From mathcomp Require Import reals.
 (*   symp A == symmetric part of matrix A                                     *)
 (*  antip A == antisymmetric part of matrix A                                 *)
 (*  spin_eigenvalues u == eigenvalues of \S(u)                                *)
+(* ```                                                                        *)
 (*                                                                            *)
 (* Cayley transform:                                                          *)
+(* ```                                                                        *)
 (*    cayley M == (1 - M)^-1 * (1 + M)                                        *)
 (*  uncayley M == (M - 1) * (M + 1)^-1                                        *)
+(* ```                                                                        *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -533,7 +537,7 @@ Let vector := 'rV[R]_3.
 Implicit Types u : vector.
 Implicit Types M : 'M[R]_3.
 
-Lemma sqr_spin u : \S( u ) ^+ 2 = u^T *m u - (norm u ^+ 2)%:A.
+Lemma sqr_spin u : \S( u ) ^+ 2 = u^T *m u - (`|u|_e ^+ 2)%:A.
 Proof.
 apply (symP (sqr_spin_is_sym u)); last move=> i j.
   rewrite rpredD//= ?mul_tr_vec_sym//.
@@ -556,18 +560,18 @@ case/boolP : (i == 0) => [/eqP-> _|/ifnot0P/orP[]/eqP->].
   by rewrite -eqr_opp 2!opprB opprK eq_sym subr_eq -dotmulvv dotmulE sum3E -!expr2.
 Qed.
 
-Lemma spin3 u : \S( u ) ^+ 3 = - (norm u) ^+ 2 *: \S( u ).
+Lemma spin3 u : \S( u ) ^+ 3 = - `|u|_e ^+ 2 *: \S( u ).
 Proof.
 rewrite exprS sqr_spin mulrBr -mulmxE mulmxA spin_mul_tr mul0mx add0r.
 by rewrite scalemx1 mul_mx_scalar scaleNr.
 Qed.
 
-Lemma exp_spin u n : \S( u ) ^+ n.+3 = - (norm u) ^+ 2 *: \S( u ) ^+ n.+1.
+Lemma exp_spin u n : \S( u ) ^+ n.+3 = - `|u|_e ^+ 2 *: \S( u ) ^+ n.+1.
 Proof.
-elim: n => [|n IH]; by [rewrite expr1 spin3|rewrite exprS IH -scalerAr -exprS].
+by elim: n => [|n IH]; [rewrite expr1 spin3|rewrite exprS IH -scalerAr -exprS].
 Qed.
 
-Lemma mxtrace_sqr_spin u : \tr (\S( u ) ^+ 2) = - (2%:R * (norm u) ^+ 2).
+Lemma mxtrace_sqr_spin u : \tr (\S( u ) ^+ 2) = - (2%:R * `|u|_e ^+ 2).
 Proof.
 rewrite sqr_spin linearD /= mxtrace_tr_mul linearN /= linearZ /=; apply/eqP.
 by rewrite !mxtrace_scalar subr_eq addrC mulrC -mulrBl -natrB // mul1r.
@@ -592,18 +596,18 @@ case: i => [] [] // [] // i _ /=.
 by rewrite !mxE; Simp.ord.
 Qed.
 
-Lemma char_poly_spin u : char_poly \S( u ) = 'X^3 + norm u ^+2 *: 'X.
+Lemma char_poly_spin u : char_poly \S( u ) = 'X^3 + `|u|_e ^+2 *: 'X.
 Proof.
 rewrite char_poly3 det_spin subr0 trace_anti ?spin_is_so //.
 rewrite scale0r subr0 expr0n add0r mulrN mxtrace_sqr_spin mulrN opprK.
 by rewrite mulrA div1r mulVr ?unitfE ?pnatr_eq0 // mul1r.
 Qed.
 
-Definition spin_eigenvalues u : seq R[i] := [:: 0; 0 +i* norm u ; 0 -i* norm u]%C.
+Definition spin_eigenvalues u : seq R[i] := [:: 0; 0 +i* `|u|_e ; 0 -i* `|u|_e]%C.
 
 Ltac eigenvalue_spin_eval_poly :=
   rewrite /map_poly horner_poly size_polyDl; [ |
-    by rewrite size_polyXn size_scale ?size_polyX // sqrf_eq0 norm_eq0];
+    by rewrite size_polyXn size_scale ?size_polyX // sqrf_eq0 enorm_eq0];
   rewrite size_polyXn sum4E !(coefD,coefXn,coefZ,coefX,expr0,expr1)
                             !(mulr0,mul0r,mul1r,add0r,addr0,mul1r).
 
@@ -628,9 +632,10 @@ case: ifPn => [|Hk].
   rewrite eqxx mulr1 mulrC (exprS _ 2) -mulrDr mulf_eq0 => /orP [/eqP ->|].
     by rewrite inE eqxx.
   rewrite eq_sym addrC -subr_eq add0r -mulN1r -sqr_i => H.
-  have {H}: (norm u)*i%C ^+2 == k ^+2.
-    rewrite -(eqP H) eq_complex. simpc. by rewrite /= !(mulr0,add0r,mul0r,eqxx).
-  rewrite eqf_sqr => /orP [/eqP <-|].
+  have {H}: `|u|_e *i%C ^+2 == k ^+2.
+    rewrite -(eqP H) eq_complex. simpc.
+    by rewrite /= !(mulr0,add0r,mul0r,eqxx).
+  rewrite eqf_sqr => /predU1P[<-|].
     by rewrite !inE eqxx orbC.
   rewrite -eqr_oppLR => /eqP <-.
   rewrite !inE orbA; apply/orP; right.
@@ -695,7 +700,7 @@ Qed.
 Lemma skew_det1BM n (M : 'M[R]_n.+1) : M \is 'so[R]_n.+1 -> \det (1 - M) != 0.
 Proof.
 move=> Mso; apply/det0P => -[v v0]; apply/eqP; rewrite mulmxBr mulmx1 subr_eq0.
-apply: contra v0 => /eqP v1M; rewrite -norm_eq0 -sqrf_eq0 -dotmulvv {2}v1M.
+apply: contra v0 => /eqP v1M; rewrite -enorm_eq0 -sqrf_eq0 -dotmulvv {2}v1M.
   by have /eqP := skew_dotmulmx v Mso; rewrite -eq_sym dotmulNv eqrNxx.
 Qed.
 
@@ -703,50 +708,50 @@ Qed.
 Lemma skew_det1DM n (M : 'M[R]_n.+1) : M \is 'so[R]_n.+1 -> \det (1 + M) != 0.
 Proof.
 move=> Mso; apply/det0P => -[v v0]; apply/eqP; rewrite mulmxDr mulmx1 addr_eq0.
-apply: contra v0 => /eqP v1M; rewrite -norm_eq0 -sqrf_eq0 -dotmulvv {2}v1M.
+apply: contra v0 => /eqP v1M; rewrite -enorm_eq0 -sqrf_eq0 -dotmulvv {2}v1M.
 have /eqP := skew_dotmulmx v Mso.
 by rewrite -eq_sym dotmulNv eqrNxx dotmulvN eqr_oppLR oppr0.
 Qed.
 
 Lemma inv1BM u : (1 - \S(u)) *
-  (1 + (1 + (norm u)^+2)^-1 *: \S(u) + (1 + (norm u)^+2)^-1 *: \S(u)^+2) = 1.
+  (1 + (1 + `|u|_e ^+ 2)^-1 *: \S(u) + (1 + `|u|_e ^+ 2)^-1 *: \S(u)^+2) = 1.
 Proof.
 rewrite mulrDr 2!mulrBl 2!mul1r.
 apply/eqP; rewrite eq_sym addrC -subr_eq; apply/eqP.
 rewrite opprD addrA opprD addrA subrr add0r opprK addrC.
 rewrite mulrDr mulr1 (addrC \S(u)) scalerAr -addrA; congr (_ + _).
 rewrite mulrA -expr2 -scalerAr -exprSr spin3 -{1}(scale1r \S(u)).
-rewrite -{1}(@divff _ (1 + norm u ^+ 2)) ?paddr_eq0 ?oner_eq0 ?sqr_ge0//.
+rewrite -{1}(@divff _ (1 + `|u|_e ^+ 2)) ?paddr_eq0 ?oner_eq0 ?sqr_ge0//.
 rewrite mulrC -scalerA -scalerBr -scalerN scaleNr opprK; congr (_ *: _).
 by rewrite scalerDl scale1r addrAC subrr add0r.
 Qed.
 
 Lemma inv1BME u : (1 - \S(u))^-1 =
-  1 + (1 + (norm u)^+2)^-1 *: \S(u) + (1 + (norm u)^+2)^-1 *: \S(u)^+2.
+  1 + (1 + `|u|_e ^+ 2)^-1 *: \S(u) + (1 + `|u|_e ^+ 2)^-1 *: \S(u)^+2.
 Proof.
 rewrite -[LHS]mulmx1 -[X in _ *m X = _](inv1BM u) mulmxA mulVmx ?mul1mx//.
 by rewrite unitmxE unitfE skew_det1BM // spin_is_so.
 Qed.
 
 (* TODO: move? *)
-Lemma det_sub1spin3E M : M \is 'so[R]_3 -> \det (1 - M) = 1 + norm (unspin M) ^+ 2.
+Lemma det_sub1spin3E M : M \is 'so[R]_3 -> \det (1 - M) = 1 + `|unspin M|_e ^+ 2.
 Proof.
 move=> Mso; rewrite -{1}(unspinK Mso); set v := \S( _ ).
 rewrite det_mx33 [v]lock !mxE /=. Simp.r.
 rewrite -lock /v !spinij subr0. Simp.r.
 rewrite -!addrA; congr (_ + _); rewrite !addrA.
-by rewrite mulrBr opprB addrA mulrDr addrA mulrCA subrK addrAC sqr_norm sum3E.
+by rewrite mulrBr opprB addrA mulrDr addrA mulrCA subrK addrAC sqr_enorm sum3E.
 Qed.
 
 (* TODO: move? *)
-Lemma det_add1spin3E M : M \is 'so[R]_3 -> \det (1 + M) = 1 + norm (unspin M) ^+ 2.
+Lemma det_add1spin3E M : M \is 'so[R]_3 -> \det (1 + M) = 1 + `|unspin M|_e ^+ 2.
 Proof.
 move=> Mso; rewrite -{1}(unspinK Mso); set v := \S( _ ).
 rewrite det_mx33 [v]lock !mxE /=. Simp.r.
 rewrite -lock /v !spinij addr0. Simp.r.
 rewrite -!addrA; congr (_ + _); rewrite !addrA.
-rewrite sqr_norm sum3E -!expr2 -!addrA; congr (_ + _).
-rewrite mulrDr -expr2 (addrC _ (_^+2)) -!addrA addrC; congr (_ + _).
+rewrite sqr_enorm sum3E -!expr2 -!addrA; congr (_ + _).
+rewrite mulrDr -expr2 (addrC _ (_ ^+ 2)) -!addrA addrC; congr (_ + _).
 by rewrite mulrBr opprB -expr2 addrCA mulrCA subrr addr0.
 Qed.
 
@@ -855,11 +860,11 @@ Definition cayley21 (a b c : R) := (b * c + a) *+ 2.
 Definition cayley22 (a b c : R) := 1 - a ^+ 2 - b ^+ 2 + c ^+ 2.
 
 Lemma sqr_norm_row3 (a b c : R) :
-  (norm (row3 a b c)) ^+ 2 = a ^+ 2 + b ^+ 2 + c ^+ 2.
+  `|row3 a b c|_e ^+ 2 = a ^+ 2 + b ^+ 2 + c ^+ 2.
 Proof. by rewrite -dotmulvv dotmulE sum3E !mxE/= -!expr2. Qed.
 
 (* result of the Cayley transform expressed with Rodrigues' parameters *)
-Lemma cayleyE (a b c : R) : let r := euclidean.norm (row3 a b c) in
+Lemma cayleyE (a b c : R) : let r := `|row3 a b c|_e in
   cayley \S((row3 a b c)) = (1 + r ^+ 2)^-1 *: (col_mx3
   (row3 (cayley00 a b c) (cayley01 a b c) (cayley02 a b c))
   (row3 (cayley10 a b c) (cayley11 a b c) (cayley12 a b c))

--- a/vec_angle.v
+++ b/vec_angle.v
@@ -1,5 +1,5 @@
 (* coq-robot (c) 2017 AIST and INRIA. License: LGPL-2.1-or-later. *)
-From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum rat poly.
+From mathcomp Require Import all_boot all_order ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import sesquilinear.
 From mathcomp Require Import realalg complex fingroup perm reals interval trigo.
@@ -46,8 +46,8 @@ Import Order.TTheory GRing.Theory Num.Def Num.Theory.
 
 Local Open Scope ring_scope.
 
-Lemma norm_le1 [T : rcfType] (u : 'rV[T]_2) :
-  norm u <= 1 -> (- 1 <= u``_ 0 <= 1) /\ (- 1 <= u``_1 <= 1).
+Lemma enorm_le1 [T : rcfType] (u : 'rV[T]_2) :
+  `| u |_e <= 1 -> (- 1 <= u``_ 0 <= 1) /\ (- 1 <= u``_1 <= 1).
 Proof.
 move=> nuL1; rewrite -!ler_norml.
 rewrite -!(expr_le1 (_ : 0 < 2)%N (normr_ge0 _)) //.
@@ -56,22 +56,22 @@ suff sL1 : `|u``_0| ^+ 2 + `|u``_1| ^+ 2 <= 1.
     by rewrite -[X in X <= _]addr0 lerD // sqr_ge0.
   by rewrite -[X in X <= _]add0r lerD // sqr_ge0.
 rewrite !sqr_normr //.
-suff : norm u ^+ 2 <= 1 by rewrite sqr_norm sum2E.
-by apply: exprn_ile1 (norm_ge0 _) _.
+suff : `| u |_e ^+ 2 <= 1 by rewrite sqr_enorm sum2E.
+by apply: exprn_ile1 (enorm_ge0 _) _.
 Qed.
 
-Lemma norm1_cossin (T : realType) (v : 'rV[T]_2) :
-  norm v = 1 -> {a | v``_0 = cos a /\ v``_1 = sin a}.
+Lemma enorm1_cossin (T : realType) (v : 'rV[T]_2) :
+  `| v |_e = 1 -> {a | v``_0 = cos a /\ v``_1 = sin a}.
 Proof.
 move=> nvE.
 exists (if 0 <= v``_1 then acos v``_0 else -acos v``_0).
-have /norm_le1[v0B v1B] : norm v <= 1 by rewrite nvE.
+have /enorm_le1[v0B v1B] : `| v |_e <= 1 by rewrite nvE.
 have [v0_ge0|v0_gt0] := leP 0%R (v``_1).
   rewrite acosK ?in_itv //= sin_acos ?in_itv //=.
-  rewrite -(expr1n T 2) -nvE sqr_norm sum2E [_ + _^+2] addrC addrK.
+  rewrite -(expr1n T 2) -nvE sqr_enorm sum2E [_ + _^+2] addrC addrK.
   by rewrite sqrtr_sqr ger0_norm.
 rewrite cosN sinN acosK ?in_itv //= sin_acos ?in_itv //=.
-rewrite -(expr1n T 2) -nvE sqr_norm sum2E [_ + _^+2] addrC addrK.
+rewrite -(expr1n T 2) -nvE sqr_enorm sum2E [_ + _^+2]addrC addrK.
 by rewrite sqrtr_sqr ltr0_norm ?opprK.
 Qed.
 
@@ -81,7 +81,7 @@ Implicit Types u v : 'rV[T]_3.
 
 Definition vec_angle v w : T :=
   if v == 0 then 0 else
-  if w == 0 then 0 else acos (v *d w / (norm v * norm w)).
+  if w == 0 then 0 else acos (v *d w / (`| v |_e * `| w |_e)).
 
 Lemma vec_anglev0 v : vec_angle v 0 = 0.
 Proof. by rewrite /vec_angle eqxx if_same. Qed.
@@ -93,14 +93,14 @@ Definition vec_angle0 := (vec_anglev0, vec_angle0v).
 
 Lemma vec_angleC v w : vec_angle v w = vec_angle w v.
 Proof.
-by rewrite /vec_angle  dotmulC [norm _ * _]mulrC; do 2 case: eqP.
+by rewrite /vec_angle  dotmulC [`| _ |_e * _]mulrC; do 2 case: eqP.
 Qed.
 
 Lemma vec_anglevZ u v k : 0 < k -> vec_angle u (k *: v) = vec_angle u v.
 Proof.
 move=> k_gt0; rewrite /vec_angle; case: eqP => // /eqP u0.
 rewrite scaler_eq0 (negPf (lt0r_neq0 _)) //=.
-rewrite dotmulvZ normZ gtr0_norm // mulrCA -mulf_div divff ?mul1r //.
+rewrite dotmulvZ enormZ gtr0_norm // mulrCA -mulf_div divff ?mul1r//.
 by rewrite lt0r_neq0.
 Qed.
 
@@ -111,7 +111,7 @@ Lemma vec_anglevZN u v k : k < 0 -> vec_angle u (k *: v) = vec_angle u (- v).
 Proof.
 move=> k_lt0; rewrite /vec_angle; case: eqP => // /eqP u0.
 rewrite scaler_eq0 (negPf (ltr0_neq0 _)) //= oppr_eq0.
-rewrite dotmulvZ normZ ltr0_norm // normN dotmulvN mulrCA -mulf_div.
+rewrite dotmulvZ enormZ ltr0_norm// enormN dotmulvN mulrCA -mulf_div.
 rewrite invrN mulrN divff ?(mulN1r, mulNr) //.
 by rewrite ltr0_neq0.
 Qed.
@@ -123,24 +123,24 @@ Lemma vec_anglevv u : u != 0 -> vec_angle u u = 0.
 Proof.
 move=> u0.
 rewrite /vec_angle /= (negPf u0) dotmulvv -expr2 divff ?acos1 //.
-by rewrite expf_eq0 //= norm_eq0.
+by rewrite expf_eq0 //= enorm_eq0.
 Qed.
 
 Lemma dotmul_div_N11 v w :
-  v != 0 -> w != 0 -> v *d w / (norm v * norm w) \in `[(-1), 1].
+  v != 0 -> w != 0 -> v *d w / (`| v |_e * `| w |_e) \in `[(-1), 1].
 Proof.
 move=> u0 v0.
 rewrite in_itv /= -ler_norml -(expr_le1 (_ : 0 < 2)%N) //.
 rewrite sqr_normr expr_div_n ler_pdivrMr ?mul1r.
-rewrite -subr_ge0 -norm_crossmul' ?exprn_ge0 ?norm_ge0 //.
-by rewrite exprn_gt0 // mulr_gt0 // norm_gt0.
+rewrite -subr_ge0 -enorm_crossmul' ?exprn_ge0 ?enorm_ge0//.
+by rewrite exprn_gt0// mulr_gt0// enorm_gt0.
 Qed.
 
 Lemma cos_vec_angleNv v w : v != 0 -> w != 0 ->
   cos (vec_angle (- v) w) = - cos (vec_angle v w).
 Proof.
 move=> u0 v0.
-rewrite /vec_angle oppr_eq0 (negPf u0) (negPf v0) normN dotmulNv mulNr.
+rewrite /vec_angle oppr_eq0 (negPf u0) (negPf v0) enormN dotmulNv mulNr.
 have H := dotmul_div_N11 u0 v0.
 by rewrite !acosK ?oppr_itvcc ?opprK.
 Qed.
@@ -164,21 +164,21 @@ Proof.
 rewrite /vec_angle oppr_eq0; case: eqP => [//|/eqP uD0].
 case: eqP => [//|/eqP vD0].
 have H := dotmul_div_N11 uD0 vD0; rewrite in_itv in H.
-rewrite normN dotmulvN mulNr !sin_acos ?sqrrN //.
+rewrite enormN dotmulvN mulNr !sin_acos ?sqrrN//.
 by rewrite lerNr opprK lerNl andbC.
 Qed.
 
 Lemma sin_vec_angleNv u v : sin (vec_angle (- u) v) = sin (vec_angle u v).
 Proof. by rewrite vec_angleC [in RHS]vec_angleC [in LHS]sin_vec_anglevN. Qed.
 
-Lemma dotmul_cos u v : u *d v = norm u * norm v * cos (vec_angle u v).
+Lemma dotmul_cos u v : u *d v = `| u |_e * `| v |_e * cos (vec_angle u v).
 Proof.
 wlog /andP[u0 v0] : u v / (u != 0) && (v != 0).
-  case/boolP : (u == 0) => [/eqP ->{u}|u0]; first by rewrite dotmul0v norm0 !mul0r.
-  case/boolP : (v == 0) => [/eqP ->{v}|v0]; first by rewrite dotmulv0 norm0 !(mulr0,mul0r).
-  apply; by rewrite u0.
-rewrite /vec_angle (negPf u0) (negPf v0) acosK; last by apply: dotmul_div_N11.
-by rewrite mulrC divfK // mulf_eq0 negb_or !norm_eq0 u0.
+  have [->|u0] := eqVneq u 0; first by rewrite dotmul0v enorm0 !mul0r.
+  have [->|v0] := eqVneq v 0; first by rewrite dotmulv0 enorm0 !(mulr0,mul0r).
+  by apply; rewrite u0.
+rewrite /vec_angle (negPf u0) (negPf v0) acosK; last exact: dotmul_div_N11.
+by rewrite mulrC divfK // mulf_eq0 negb_or !enorm_eq0 u0.
 Qed.
 
 Lemma dotmul0_vec_angle u v : u != 0 -> v != 0 ->
@@ -189,13 +189,13 @@ by rewrite /vec_angle (negPf u0) (negPf v0) uv0 mul0r acos0 sin_pihalf normr1.
 Qed.
 
 Lemma triine u v :
-  (norm u * norm v * cos (vec_angle u v)) *+ 2 <= norm u ^+ 2 + norm v ^+ 2.
+  (`| u |_e * `| v |_e * cos (vec_angle u v)) *+ 2 <= `| u |_e ^+ 2 + `| v |_e ^+ 2.
 Proof.
-move/eqP: (sqrrD (norm u) (norm v)); rewrite addrAC -subr_eq => /eqP <-.
-rewrite lerBrDr -mulrnDl -{2}(mulr1 (norm u * norm v)) -mulrDr.
-apply (@le_trans _ _ (norm u * norm v * 2%:R *+ 2)).
+move/eqP: (sqrrD `|u|_e `|v|_e); rewrite addrAC -subr_eq => /eqP <-.
+rewrite lerBrDr -mulrnDl -{2}(mulr1 (`|u|_e * `|v|_e)) -mulrDr.
+apply (@le_trans _ _ (`|u|_e * `|v|_e * 2%:R *+ 2)).
   rewrite lerMn2r /=; apply ler_pM => //.
-    by apply mulr_ge0; apply norm_ge0.
+    by apply mulr_ge0; apply: enorm_ge0.
     rewrite -lerBlDr add0r; move: (cos_max (vec_angle u v)).
     by rewrite ler_norml => /andP[].
   rewrite -lerBrDr {2}(_ : 1 = 1%:R) // -natrB //.
@@ -204,43 +204,45 @@ rewrite sqrrD mulr2n addrAC; apply: lerD; last by rewrite mulr_natr.
 by rewrite -subr_ge0 addrAC mulr_natr -sqrrB sqr_ge0.
 Qed.
 
-Lemma normB u v : norm (u - v) ^+ 2 =
-  norm u ^+ 2 + norm u * norm v * cos (vec_angle u v) *- 2 + norm v ^+ 2.
+(* TODO: move? *)
+Lemma enormB u v : `|u - v|_e ^+ 2 =
+  `|u|_e ^+ 2 + `|u|_e * `|v|_e * cos (vec_angle u v) *- 2 + `|v|_e ^+ 2.
 Proof.
-rewrite /norm dotmulD {1}dotmulvv sqr_sqrtr; last first.
+rewrite /enorm dotmulD {1}dotmulvv sqr_sqrtr; last first.
   rewrite !dotmulvN !dotmulNv opprK dotmulvv dotmul_cos.
   by rewrite addrAC mulNrn subr_ge0 triine.
-rewrite sqr_sqrtr ?le0dotmul // !dotmulvv !sqrtr_sqr normN dotmulvN dotmul_cos.
-by rewrite ger0_norm ?norm_ge0 // ger0_norm ?norm_ge0 // mulNrn.
+rewrite sqr_sqrtr ?le0dotmul // !dotmulvv !sqrtr_sqr enormN dotmulvN dotmul_cos.
+by rewrite ger0_norm ?enorm_ge0// ger0_norm ?enorm_ge0// mulNrn.
 Qed.
 
-Lemma normD u v : norm (u + v) ^+ 2 =
-  norm u ^+ 2 + norm u * norm v * cos (vec_angle u v) *+ 2 + norm v ^+ 2.
+(* TODO: move? *)
+Lemma enormD u v : `|u + v|_e ^+ 2 =
+  `|u|_e ^+ 2 + `|u|_e * `|v|_e * cos (vec_angle u v) *+ 2 + `|v|_e ^+ 2.
 Proof.
 rewrite {1}(_ : v = - - v); last by rewrite opprK.
-rewrite normB normN.
-case/boolP: (u == 0) => [/eqP ->|u0].
-  by rewrite !(norm0,expr0n,add0r,vec_angle0,mul0r,mul0rn,oppr0).
-case/boolP: (v == 0) => [/eqP ->|v0].
-  by rewrite norm0 mulr0 oppr0 vec_angle0 cos0 mul0r mul0rn subr0 addr0.
+rewrite enormB enormN.
+have [->|u0] := eqVneq u 0.
+  by rewrite !(enorm0,expr0n,add0r,vec_angle0,mul0r,mul0rn,oppr0).
+have [->|v0] := eqVneq v 0.
+  by rewrite enorm0 mulr0 oppr0 vec_angle0 cos0 mul0r mul0rn subr0 addr0.
 by rewrite [in LHS]cos_vec_anglevN // mulrN mulNrn opprK.
 Qed.
 
 Lemma cosine_law' a b c :
-  norm (b - c) ^+ 2 = norm (c - a) ^+ 2 + norm (b - a) ^+ 2 -
-  norm (c - a) * norm (b - a) * cos (vec_angle (b - a) (c - a)) *+ 2.
+  `|b - c|_e ^+ 2 = `|c - a|_e ^+ 2 + `|b - a|_e ^+ 2 -
+  `|c - a|_e * `|b - a|_e * cos (vec_angle (b - a) (c - a)) *+ 2.
 Proof.
 rewrite -[in LHS]dotmulvv (_ : b - c = b - a - (c - a)); last first.
   by rewrite -!addrA opprB (addrC (- a)) (addrC a) addrK.
 rewrite dotmulD dotmulvv [in X in _ + _ + X = _]dotmulvN dotmulNv opprK.
-rewrite dotmulvv dotmulvN addrAC (addrC (norm (b - a) ^+ _)); congr (_ + _).
-by rewrite dotmul_cos mulNrn (mulrC (norm (b - a))).
+rewrite dotmulvv dotmulvN addrAC (addrC (`|b - a|_e ^+ _)); congr (_ + _).
+by rewrite dotmul_cos mulNrn (mulrC `|b - a|_e).
 Qed.
 
-Lemma cosine_law a b c : norm (c - a) != 0 -> norm (b - a) != 0 ->
+Lemma cosine_law a b c : `|c - a|_e != 0 -> `|b - a|_e != 0 ->
   cos (vec_angle (b - a) (c - a)) =
-  (norm (b - c) ^+ 2 - norm (c - a) ^+ 2 - norm (b - a) ^+ 2) /
-  (norm (c - a) * norm (b - a) *- 2).
+  (`|b - c|_e ^+ 2 - `|c - a|_e ^+ 2 - `|b - a|_e ^+ 2) /
+  (`|c - a|_e * `|b - a|_e *- 2).
 Proof.
 move=> H0 H1.
 rewrite (cosine_law' a b c) -2!addrA addrCA -opprD subrr addr0.
@@ -253,51 +255,51 @@ rewrite -mulrA mulf_eq0 pnatr_eq0/=.
 by rewrite mulf_eq0 negb_or H0 H1.
 Qed.
 
-Lemma norm_crossmul u v :
-  norm (u *v v) = norm u * norm v * `| sin (vec_angle u v) |.
+Lemma enorm_crossmul u v :
+  `|u *v v|_e = `|u|_e * `|v|_e * `| sin (vec_angle u v) |.
 Proof.
-suff /eqP : (norm (u *v v))^+2 = (norm u * norm v * `| sin (vec_angle u v) |)^+2.
-  rewrite -eqr_sqrt ?sqr_ge0 // 2!sqrtr_sqr ger0_norm; last by rewrite norm_ge0.
+suff /eqP : `|u *v v|_e ^+ 2 = (`|u|_e * `|v|_e * `| sin (vec_angle u v) |)^+2.
+  rewrite -eqr_sqrt ?sqr_ge0 // 2!sqrtr_sqr ger0_norm; last by rewrite enorm_ge0.
   rewrite ger0_norm; first by move/eqP.
-  by rewrite -mulrA mulr_ge0 // ?norm_ge0 // mulr_ge0 // ? norm_ge0.
-rewrite norm_crossmul' dotmul_cos !exprMn.
+  by rewrite -mulrA mulr_ge0 ?enorm_ge0 // mulr_ge0 // enorm_ge0.
+rewrite enorm_crossmul' dotmul_cos !exprMn.
 apply/eqP; rewrite subr_eq -mulrDr.
 rewrite real_normK //; first by rewrite addrC cos2Dsin2 mulr1.
 by rewrite realE; case: ltgtP.
 Qed.
 
-Lemma norm_dotmul_crossmul u v : u != 0 -> v != 0 ->
-  (`|u *d v +i* norm (u *v v)| = (norm u * norm v)%:C)%C.
+Lemma enorm_dotmul_crossmul u v : u != 0 -> v != 0 ->
+  (`|u *d v +i* `|u *v v|_e| = (`|u|_e * `|v|_e)%:C)%C.
 Proof.
 move=> u0 v0 .
-rewrite {1}dotmul_cos {1}norm_crossmul normc_def.
+rewrite {1}dotmul_cos {1}enorm_crossmul normc_def.
 rewrite exprMn (@exprMn _ 2 _ `| sin _ |) -mulrDr.
 rewrite sqrtrM ?sqr_ge0 // sqr_normr cos2Dsin2 sqrtr1 mulr1.
-rewrite sqrtr_sqr normrM; by do 2 rewrite ger0_norm ?norm_ge0 //.
+by rewrite sqrtr_sqr normrM; do 2 rewrite ger0_norm ?enorm_ge0//.
 Qed.
 
 Lemma vec_angle0_inv u v : u != 0 -> v != 0 ->
-  vec_angle u v = 0 -> u = (norm u / norm v) *: v.
+  vec_angle u v = 0 -> u = (`|u|_e / `|v|_e) *: v.
 Proof.
 move=> uD0 vD0 uv0.
-apply/eqP; rewrite -subr_eq0 -norm_eq0.
-rewrite -(@eqrXn2 _ 2) // ?norm_ge0 // expr0n /= normB.
-rewrite vec_anglevZ; last by rewrite divr_gt0 // norm_gt0.
-rewrite uv0 cos0 mulr1 !normZ ger0_norm; last first.
-  by rewrite divr_ge0 // norm_ge0.
-by rewrite divfK ?norm_eq0 // -expr2 addrAC -mulr2n subrr.
+apply/eqP; rewrite -subr_eq0 -enorm_eq0.
+rewrite -(@eqrXn2 _ 2) ?enorm_ge0// expr0n /= enormB.
+rewrite vec_anglevZ; last by rewrite divr_gt0// enorm_gt0.
+rewrite uv0 cos0 mulr1 !enormZ ger0_norm; last first.
+  by rewrite divr_ge0// enorm_ge0.
+by rewrite divfK ?enorm_eq0// -expr2 addrAC -mulr2n subrr.
 Qed.
 
 Lemma vec_anglepi_inv u v : u != 0 -> v != 0 ->
-  vec_angle u v = pi -> u = - (norm u / norm v) *: v.
+  vec_angle u v = pi -> u = - (`|u|_e / `|v|_e) *: v.
 Proof.
 move=> uD0 vD0 uvpi.
-apply/eqP; rewrite -subr_eq0 -norm_eq0 scaleNr opprK.
-rewrite -(@eqrXn2 _ 2) // ?norm_ge0 // expr0n /= normD.
-rewrite vec_anglevZ; last by rewrite divr_gt0 // norm_gt0.
-rewrite uvpi cospi mulrN1 !normZ ger0_norm; last first.
-  by rewrite divr_ge0 // norm_ge0.
-rewrite mulNrn divfK ?norm_eq0 //.
+apply/eqP; rewrite -subr_eq0 -enorm_eq0 scaleNr opprK.
+rewrite -(@eqrXn2 _ 2) ?enorm_ge0// expr0n /= enormD.
+rewrite vec_anglevZ; last by rewrite divr_gt0// enorm_gt0.
+rewrite uvpi cospi mulrN1 !enormZ ger0_norm; last first.
+  by rewrite divr_ge0// enorm_ge0.
+rewrite mulNrn divfK ?enorm_eq0//.
 by rewrite addrC addrA -expr2 -mulr2n subrr.
 Qed.
 
@@ -309,31 +311,31 @@ have := dotmul_div_N11 uD0 vD0; rewrite in_itv /= => uv_bound.
 by rewrite acos_ge0 // acos_lepi.
 Qed.
 
-Lemma dotmul1_inv u v : norm u = 1 -> norm v = 1 -> u *d v = 1 -> u = v.
+Lemma dotmul1_inv u v : `|u|_e = 1 -> `|v|_e = 1 -> u *d v = 1 -> u = v.
 Proof.
 move=> u1 v1; rewrite dotmul_cos u1 v1 2!mul1r => Huv.
-suff: u = (norm u / norm v) *: v.
+suff: u = (`|u|_e / `|v|_e) *: v.
 rewrite u1 v1 ?divff ?(scale1r, oner_neq0) //.
-apply: vec_angle0_inv; first by rewrite -norm_eq0 u1 oner_neq0.
-  by rewrite -norm_eq0 v1 oner_neq0.
+apply: vec_angle0_inv; first by rewrite -enorm_eq0 u1 oner_neq0.
+  by rewrite -enorm_eq0 v1 oner_neq0.
 apply: cos_inj; rewrite ?in_itv /=; last by rewrite cos0.
   by apply: vec_angle_bound.
 by rewrite lexx pi_ge0.
 Qed.
 
-Lemma dotmulN1_inv u v : norm u = 1 -> norm v = 1 -> u *d v = - 1 -> u = - v.
+Lemma dotmulN1_inv u v : `|u|_e = 1 -> `|v|_e = 1 -> u *d v = - 1 -> u = - v.
 Proof.
 move=> u1 v1 Huv.
-by apply: dotmul1_inv; rewrite ?normN // dotmulvN Huv opprK.
+by apply: dotmul1_inv; rewrite ?enormN// dotmulvN Huv opprK.
 Qed.
 
 Lemma cos_vec_angle a b : a != 0 -> b != 0 ->
-  `| cos (vec_angle a b) | = Num.sqrt (1 - (norm (a *v b) / (norm a * norm b)) ^+ 2).
+  `| cos (vec_angle a b) | = Num.sqrt (1 - (`|a *v b|_e / (`|a|_e * `|b|_e)) ^+ 2).
 Proof.
 move=> Ha Hb.
-rewrite norm_crossmul mulrAC divrr // ?mul1r.
+rewrite enorm_crossmul mulrAC divrr // ?mul1r.
   by rewrite sqr_normr -cos2sin2 sqrtr_sqr.
-by rewrite unitfE mulf_neq0 // norm_eq0.
+by rewrite unitfE mulf_neq0// enorm_eq0.
 Qed.
 
 Lemma orth_preserves_vec_angle M : M \is 'O[T]_3 ->
@@ -343,8 +345,8 @@ move=> MO v w.
 have [->|/eqP vD0]:= v =P 0; first by rewrite mul0mx !vec_angle0.
 have [->|/eqP wD0]:= w =P 0; first by rewrite mul0mx !vec_angle0.
 apply: cos_inj; try by apply: vec_angle_bound.
-have /mulfI : norm v * norm w != 0.
-  by rewrite mulf_eq0 !norm_eq0 negb_or vD0 wD0.
+have /mulfI : `|v|_e * `|w|_e != 0.
+  by rewrite mulf_eq0 !enorm_eq0 negb_or vD0 wD0.
 apply; rewrite -[RHS]dotmul_cos.
 have /orth_preserves_dotmul/(_ v w)<-  := MO.
 by rewrite [RHS]dotmul_cos !orth_preserves_norm.
@@ -515,13 +517,13 @@ Lemma axialcomp0v e : axialcomp 0 e = 0.
 Proof. by rewrite /axialcomp dotmulv0 scale0r. Qed.
 
 Lemma axialcompv0 v : axialcomp v 0 = 0.
-Proof. by rewrite /axialcomp /normalize norm0 invr0 ?(scale0r,dotmul0v). Qed.
+Proof. by rewrite /axialcomp /normalize enorm0 invr0 ?(scale0r,dotmul0v). Qed.
 
-Lemma axialcompE v e : axialcomp v e = (norm e) ^- 2 *: (v *m e^T *m e).
+Lemma axialcompE v e : axialcomp v e = `|e|_e ^- 2 *: (v *m e^T *m e).
 Proof.
-have [/eqP ->|?] := boolP (e == 0); first by rewrite axialcompv0 mulmx0 scaler0.
+have [->|?] := eqVneq e 0; first by rewrite axialcompv0 mulmx0 scaler0.
 rewrite /axialcomp dotmulZv scalerA mulrAC dotmulP mul_scalar_mx dotmulC.
-by rewrite -invrM ?unitfE ?norm_eq0 // -expr2 scalerA.
+by rewrite -invrM ?unitfE ?enorm_eq0// -expr2 scalerA.
 Qed.
 
 Lemma axialcompvN v e : axialcomp v (- e) = axialcomp v e.
@@ -532,9 +534,9 @@ Proof. by rewrite /axialcomp dotmulvN scaleNr. Qed.
 
 Lemma axialcompZ k e : axialcomp (k *: e) e = k *: e.
 Proof.
-rewrite /axialcomp dotmulvZ dotmulC dotmul_normalize_norm.
+rewrite /axialcomp dotmulvZ dotmulC dotmul_normalize_enorm.
 have [/eqP u0|u0] := boolP (e == 0); first by rewrite u0 normalize0 2!scaler0.
-by rewrite scalerA -mulrA divrr ?unitfE ?norm_eq0 // mulr1.
+by rewrite scalerA -mulrA divrr ?unitfE ?enorm_eq0// mulr1.
 Qed.
 
 Lemma axialcomp_dotmul v e : e *d v = 0 -> axialcomp v e = 0.
@@ -559,15 +561,15 @@ rewrite (linearZl_LR _ e)/= (@liexx _ (vec3 T)).
 by rewrite scaler0 (linear0l _ (_ *v v)).
 Qed.
 
-Lemma norm_axialcomp v e : e *d v < 0 ->
-  norm (axialcomp v e) = - (normalize e *d v).
+Lemma enorm_axialcomp v e : e *d v < 0 ->
+  `|axialcomp v e|_e = - (normalize e *d v).
 Proof.
 move=> H.
 have ? : e != 0 by apply: contraTN H => /eqP ->; rewrite dotmul0v ltxx.
-rewrite /axialcomp scalerA normZ ltr0_norm; last first.
-  rewrite pmulr_llt0 ?invr_gt0 ?norm_gt0 //.
-  by rewrite /normalize dotmulZv pmulr_rlt0 // invr_gt0 norm_gt0.
-by rewrite mulNr -(mulrA _ _ (norm e)) mulVr ?mulr1 ?unitfE ?norm_eq0.
+rewrite /axialcomp scalerA enormZ ltr0_norm; last first.
+  rewrite pmulr_llt0 ?invr_gt0 ?enorm_gt0 //.
+  by rewrite /normalize dotmulZv pmulr_rlt0 // invr_gt0 enorm_gt0.
+by rewrite mulNr -(mulrA _ _ `|e|_e) mulVr ?mulr1 ?unitfE ?enorm_eq0.
 Qed.
 
 Lemma axialcomp_mulO Q p e : Q \is 'O[T]_3 -> e *m Q = e ->
@@ -585,8 +587,8 @@ Lemma vec_angle_axialcomp v e : 0 < e *d v ->
 Proof.
 move=> H.
 have ? : e != 0 by apply: contraTN H => /eqP ->; rewrite dotmul0v ltxx.
-rewrite /axialcomp scalerA vec_anglevZ // divr_gt0 // ?norm_gt0 //.
-by rewrite /normalize dotmulZv mulr_gt0 // invr_gt0 norm_gt0.
+rewrite /axialcomp scalerA vec_anglevZ // divr_gt0 ?enorm_gt0//.
+by rewrite /normalize dotmulZv mulr_gt0 // invr_gt0 enorm_gt0.
 Qed.
 
 Definition normalcomp v e := v - axialcomp v e.
@@ -594,7 +596,7 @@ Definition normalcomp v e := v - axialcomp v e.
 Lemma axialnormalcomp v e : v = axialcomp v e + normalcomp v e.
 Proof. by rewrite /axialcomp /normalcomp addrC subrK. Qed.
 
-Lemma normalcompE v e : normalcomp v e = v *m (1 - norm e ^-2 *: (e^T *m e)).
+Lemma normalcompE v e : normalcomp v e = v *m (1 - `|e|_e ^-2 *: (e^T *m e)).
 Proof.
 by rewrite /normalcomp axialcompE -mulmxA scalemxAr -{1}(mulmx1 v) -mulmxBr.
 Qed.
@@ -618,7 +620,7 @@ Lemma normalcompB v1 v2 : normalcomp (v1 - v2) v2 = normalcomp v1 v2.
 Proof.
 apply/esym/eqP.
 rewrite /normalcomp subr_eq /axialcomp -scaleNr -!addrA -scalerDl -dotmulvN.
-rewrite -dotmulDr opprB subrK dotmulC dotmul_normalize_norm.
+rewrite -dotmulDr opprB subrK dotmulC dotmul_normalize_enorm.
 by rewrite norm_scale_normalize addrA subrK.
 Qed.
 
@@ -644,10 +646,10 @@ Qed.
 
 Lemma dotmul_normalcomp v e : normalcomp v e *d e = 0.
 Proof.
-case/boolP : (e == 0) => [/eqP ->|?]; first by rewrite dotmulv0.
+have [->|?] := eqVneq e 0; first by rewrite dotmulv0.
 rewrite /normalcomp dotmulBl !dotmulZv dotmulvv (exprD _ 1 1) expr1.
-rewrite (mulrA (_^-1)) mulVr ?unitfE ?norm_eq0 // mul1r mulrAC.
-by rewrite mulVr ?unitfE ?norm_eq0 // mul1r dotmulC subrr.
+rewrite (mulrA (_^-1)) mulVr ?unitfE ?enorm_eq0// mul1r mulrAC.
+by rewrite mulVr ?unitfE ?enorm_eq0// mul1r dotmulC subrr.
 Qed.
 
 Lemma axialnormal v e : axialcomp v e *d normalcomp v e = 0.
@@ -673,7 +675,7 @@ rewrite -scalemxAr -scalemxAl; congr (_ *: _).
 by rewrite -{1}uQu trmx_mul !mulmxA orthogonal_mul_tr // mul1mx -mulmxA uQu.
 Qed.
 
-Lemma normalcomp_mul_tr e (e1 : norm e = 1) : normalcomp 'e_0 e *m e^T == 0.
+Lemma normalcomp_mul_tr e (e1 : `|e|_e = 1) : normalcomp 'e_0 e *m e^T == 0.
 Proof.
 rewrite /normalcomp mulmxBl -scalemxAl -scalemxAl dotmul1 // dotmulC /dotmul.
 by rewrite e1 invr1 scalemx1 scalemx1 normalizeI // {1}dotmulP subrr.
@@ -685,11 +687,11 @@ Lemma dotmul_orthogonalize v e : e *d orthogonalize v e = 0.
 Proof.
 rewrite /normalcomp /normalize dotmulBr !(dotmulZv, dotmulvZ).
 rewrite mulrACA -invfM -expr2 dotmulvv mulrCA.
-have [->|u_neq0] := eqVneq e 0; first by rewrite norm0 invr0 dotmul0v !mul0r subrr.
+have [->|u_neq0] := eqVneq e 0; first by rewrite enorm0 invr0 dotmul0v !mul0r subrr.
 rewrite norm_normalize // expr1n invr1 mul1r.
 rewrite (mulrC _ (e *d _)).
 rewrite -mulrA (mulrA (_^-1)) -expr2 -exprMn mulVr ?expr1n ?mulr1 ?subrr //.
-by rewrite unitfE norm_eq0.
+by rewrite unitfE enorm_eq0.
 Qed.
 
 End axial_normal_decomposition.
@@ -764,32 +766,32 @@ Lemma cos0sin1 [R : realType] [x : R] : cos x = 0 -> `|sin x| = 1.
 Proof. by move/eqP; rewrite -norm_sin_eq1 => /eqP. Qed.
 
 Lemma triangle_sin_vector_helper v1 v2 : ~~ colinear v1 v2 ->
-  norm v1 ^+ 2 * sin (vec_angle v1 v2) ^+ 2 = norm (normalcomp v1 v2) ^+ 2.
+  `|v1|_e ^+ 2 * sin (vec_angle v1 v2) ^+ 2 = `|normalcomp v1 v2|_e ^+ 2.
 Proof.
 move=> H.
 have v10 : v1 != 0 by apply: contra H => /eqP ->; rewrite colinear0.
 have v20 : v2 != 0 by apply: contra H => /eqP ->; rewrite colinear_sym colinear0.
-rewrite /normalcomp [in RHS]normB.
+rewrite /normalcomp [in RHS]enormB.
 case/boolP : (0 < v2 *d v1) => [v2v1|].
-  rewrite normZ gtr0_norm; last first.
-    by rewrite dotmulZv mulr_gt0 // invr_gt0 norm_gt0.
+  rewrite enormZ gtr0_norm; last first.
+    by rewrite dotmulZv mulr_gt0 // invr_gt0 enorm_gt0.
   rewrite norm_normalize // mulr1 vec_angle_axialcomp //.
   rewrite dotmul_cos norm_normalize // mul1r vec_angleZv; last first.
-    by rewrite invr_gt0 norm_gt0.
+    by rewrite invr_gt0 enorm_gt0.
   rewrite [in RHS]mulrA (vec_angleC v1) -expr2 -mulrA -expr2 exprMn.
   by rewrite mulr2n opprD addrA subrK sin2cos2 mulrBr mulr1.
 rewrite -leNgt le_eqVlt => /orP[|v2v1].
-  rewrite {1}dotmul_cos -mulrA mulf_eq0 norm_eq0 (negbTE v20) /=.
-  rewrite mulf_eq0 norm_eq0 (negbTE v10) /= => /eqP Hcos.
+  rewrite {1}dotmul_cos -mulrA mulf_eq0 enorm_eq0 (negbTE v20) /=.
+  rewrite mulf_eq0 enorm_eq0 (negbTE v10) /= => /eqP Hcos.
   rewrite axialcomp_dotmul; last by rewrite dotmul_cos Hcos mulr0.
-  rewrite norm0 mulr0 mul0r expr0n mul0rn addr0 subr0.
+  rewrite enorm0 mulr0 mul0r expr0n mul0rn addr0 subr0.
   by rewrite -(sqr_normr (sin _)) vec_angleC cos0sin1 ?expr1n ?mulr1.
 rewrite vec_anglevZN //; last first.
-  by rewrite /normalize dotmulZv pmulr_rlt0 // invr_gt0 norm_gt0.
+  by rewrite /normalize dotmulZv pmulr_rlt0 // invr_gt0 enorm_gt0.
 rewrite cos_vec_anglevN // ?normalize_eq0 //.
-rewrite norm_axialcomp // !(mulrN,mulNr,opprK,sqrrN).
-rewrite vec_anglevZ // ?invr_gt0 ?norm_gt0 //.
-rewrite dotmul_cos norm_normalize // mul1r vec_angleZv ?invr_gt0 ?norm_gt0 //.
+rewrite enorm_axialcomp // !(mulrN,mulNr,opprK,sqrrN).
+rewrite vec_anglevZ // ?invr_gt0 ?enorm_gt0//.
+rewrite dotmul_cos norm_normalize // mul1r vec_angleZv ?invr_gt0 ?enorm_gt0//.
 rewrite (vec_angleC v2) -!mulrA -expr2 exprMn addrAC -addrA -mulrA -mulrnAr.
 rewrite -mulrBr mulr2n opprD addrA subrr sub0r.
 rewrite mulrA -expr2 mulrN mulrA -expr2.
@@ -797,27 +799,27 @@ by rewrite sin2cos2 mulrBr mulr1.
 Qed.
 
 Lemma triangle_sin_vector v1 v2 : ~~ colinear v1 v2 ->
-  sin (vec_angle v1 v2) = norm (normalcomp v1 v2) / norm v1.
+  sin (vec_angle v1 v2) = `|normalcomp v1 v2|_e / `|v1|_e.
 Proof.
 move=> H.
 have v10 : v1 != 0 by apply: contra H => /eqP ->; rewrite colinear0.
 have v20 : v2 != 0 by apply: contra H => /eqP ->; rewrite colinear_sym colinear0.
 apply/eqP.
-rewrite -(@eqrXn2 _ 2) // ?divr_ge0 // ?norm_ge0 // ?sin_vec_angle_ge0 //.
+rewrite -(@eqrXn2 _ 2) // ?divr_ge0 ?enorm_ge0// ?sin_vec_angle_ge0 //.
 rewrite exprMn -triangle_sin_vector_helper // mulrAC exprVn divrr ?mul1r //.
-by rewrite unitfE sqrf_eq0 norm_eq0.
+by rewrite unitfE sqrf_eq0 enorm_eq0.
 Qed.
 
 Lemma triangle_sin_point (p1 p2 p : 'rV[T]_3) : ~~ tricolinear p1 p2 p ->
   let v1 := p1 - p in let v2 := p2 - p in
-  sin (vec_angle v1 v2) = norm (normalcomp v1 v2) / norm v1.
+  sin (vec_angle v1 v2) = `|normalcomp v1 v2|_e / `|v1|_e.
 Proof.
 move=> H v1 v2; apply triangle_sin_vector; apply: contra H.
 by rewrite tricolinear_perm 2!tricolinear_rot /tricolinear /v1 /v2 colinear_sym.
 Qed.
 
 Lemma law_of_sines_vector v1 v2 : ~~ colinear v1 v2 ->
-  sin (vec_angle v1 v2) / norm (v2 - v1) = sin (vec_angle (v2 - v1) v2) / norm v1.
+  sin (vec_angle v1 v2) / `|v2 - v1|_e = sin (vec_angle (v2 - v1) v2) / `|v1|_e.
 Proof.
 move=> H.
 move: (triangle_sin_vector H) => /= H1.
@@ -826,16 +828,16 @@ have H' : ~~ colinear v2 (v2 - v1).
   rewrite colinear_sym; apply: contra H => H.
   move: (colinear_refl v2); rewrite -colinearNv => /(colinearD H).
   by rewrite addrAC subrr add0r colinearNv.
-have H2 : sin (vec_angle v2 (v2 - v1)) = norm (normalcomp (v2 - v1) v2) / norm (v2 - v1).
+have H2 : sin (vec_angle v2 (v2 - v1)) = `|normalcomp (v2 - v1) v2|_e / `|v2 - v1|_e.
   rewrite vec_angleC; apply triangle_sin_vector; by rewrite colinear_sym.
 rewrite [in RHS]vec_angleC [in RHS]H2.
-by rewrite -normalcompB mulrAC -(opprB v2) normalcompNv normN.
+by rewrite -normalcompB mulrAC -(opprB v2) normalcompNv enormN.
 Qed.
 
 Lemma law_of_sines_point (p1 p2 p : 'rV[T]_3) : ~~ tricolinear p1 p2 p ->
   let v1 := p1 - p in let v2 := p2 - p in
-  sin (vec_angle v1 v2) / norm (p2 - p1) =
-  sin (vec_angle (p2 - p1) (p2 - p)) / norm (p1 - p).
+  sin (vec_angle v1 v2) / `|p2 - p1|_e =
+  sin (vec_angle (p2 - p1) (p2 - p)) / `|p1 - p|_e.
 Proof.
 move=> H v1 v2.
 rewrite (_ : p2 - p1 = v2 - v1); last by rewrite /v1 /v2 opprB addrA subrK.
@@ -1065,7 +1067,7 @@ Variable T : rcfType.
 Let point := 'rV[T]_3.
 
 Definition distance_point_line (p : point) l : T :=
-  norm ((p - \pt( l )) *v \vec( l )) / norm \vec( l ).
+  `|(p - \pt( l )) *v \vec( l )|_e / `|\vec( l )|_e.
 
 Definition distance_between_lines (l1 l2 : Line.t T) : T :=
   if intersects l1 l2 then
@@ -1074,6 +1076,6 @@ Definition distance_between_lines (l1 l2 : Line.t T) : T :=
     distance_point_line \pt( l1 ) l2
   else (* skew lines *)
     let n := \vec( l1 ) *v \vec( l2 ) in
-    `| (\pt( l2 ) - \pt( l1 )) *d n | / norm n.
+    `| (\pt( l2 ) - \pt( l1 )) *d n | / `|n|_e.
 
 End distance_line.


### PR DESCRIPTION
This PR is essentially renaming the euclidean norm to `enorm` and introduces the notation `| ... |_e` for it.
This is for clarity, in particular to avoid confusion with MathComp's `norm` instantiated in MathComp-Analysis
for matrices as the max-norm.

fyi: @holgerthies @yosakaon @chrjx @weng-chenghui

