### PR TITLE
Adapt to Rocq 9.1 + mathcomp 2.6 + analysis >= 1.16

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -18,8 +18,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'mathcomp/mathcomp:2.5.0-rocq-prover-9.0'
-          - 'mathcomp/mathcomp:2.5.0-rocq-prover-9.1'
+          - 'mathcomp/mathcomp-dev:rocq-prover-9.1'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'mathcomp/mathcomp-dev:rocq-prover-9.1'
+          - 'mathcomp/mathcomp:rocq-prover-9.1'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         image:
           - 'rocq/rocq-prover:9.1'
-          - 'rocq/rocq-prover:9.2'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'mathcomp/mathcomp:rocq-prover-9.1'
+          - 'rocq/rocq-prover:rocq-prover-9.1'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -18,7 +18,8 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'rocq/rocq-prover:rocq-prover-9.1'
+          - 'rocq/rocq-prover:9.1'
+          - 'rocq/rocq-prover:9.2'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Mathematical Components library.
   - Cyril Cohen, Inria (initial)
   - Laurent Théry, Inria
 - License: [LGPL-2.1-or-later](LICENSE)
+- Compatible Rocq/Coq versions: Rocq 9.0--9.3
 - Additional dependencies:
   - [Hierarchy Builder](https://github.com/math-comp/hierarchy-builder)
   - [MathComp ssreflect](https://math-comp.github.io)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Mathematical Components library.
   - Cyril Cohen, Inria (initial)
   - Laurent Théry, Inria
 - License: [LGPL-2.1-or-later](LICENSE)
-- Compatible Rocq/Coq versions: Rocq 9.0--9.3
 - Additional dependencies:
   - [Hierarchy Builder](https://github.com/math-comp/hierarchy-builder)
   - [MathComp ssreflect](https://math-comp.github.io)
@@ -33,7 +32,6 @@ Mathematical Components library.
   - [MathComp field](https://math-comp.github.io)
   - [MathComp analysis](https://github.com/math-comp/analysis)
   - [MathComp real closed](https://github.com/math-comp/real-closed)
-  - [MathComp algebra tactics](https://github.com/math-comp/algebra-tactics)
 - Rocq/Coq namespace: `robot`
 - Related publication(s):
   - [Formal foundations of 3D geometry to model robot manipulators](https://staff.aist.go.jp/reynald.affeldt/documents/robot_cpp_long.pdf) doi:[10.1145/3018610.3018629](https://doi.org/10.1145/3018610.3018629)

--- a/angle.v
+++ b/angle.v
@@ -1,6 +1,6 @@
 (* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From HB Require Import structures.
-From mathcomp Require Import all_boot all_order ssralg ssrint.
+From mathcomp Require Import boot order ssralg ssrint.
 From mathcomp Require Import ssrnum rat poly closed_field polyrcf matrix.
 From mathcomp Require Import mxalgebra tuple mxpoly zmodp binomial realalg.
 From mathcomp Require Import complex finset fingroup perm.
@@ -149,9 +149,9 @@ Qed.
 Lemma expi_conjc (a : T[i]) : a != 0 -> (expi (arg a))^-1 = expi (arg a^*).
 Proof.
 case: a => a b a0 /=; rewrite expi_arg // expi_arg.
-  by apply: contra a0 => a0; rewrite -conjc_eq0.
+  by rewrite conjc_eq0.
 rewrite invc_norm (_ : `| _ | = 1).
-  by rewrite normrM normrV ?unitfE ?normr_eq0 // normr_id divrr // unitfE normr_eq0.
+  by rewrite normrM normrV ?unitfE ?normr_eq0// normr_id divff// normr_eq0.
 rewrite exprnN exp1rz mul1r. simpc. by rewrite /= sqrrN.
 Qed.
 
@@ -346,14 +346,14 @@ Lemma arg0_inv (x : T[i]) y : y != 0 -> `|x| = y -> arg x = 0 -> x = y.
 Proof.
 move=> y0; case: x => x1 x2 norma H.
 rewrite -(mulr1 y) -expi0 -H expi_arg; first by rewrite -normr_eq0 norma.
-by rewrite norma mulrCA divrr // mulr1.
+by rewrite norma mulrCA divff ?mulr1.
 Qed.
 
 Lemma argpi_inv (x : T[i]) y : y != 0 -> `|x| = y -> arg x = pi -> x = - y.
 Proof.
 move=> y0; case: x => x1 x2 norma H.
 rewrite -(mulrN1 y) -expipi -H expi_arg; first by rewrite -normr_eq0 norma.
-by rewrite norma mulrCA divrr // mulr1.
+by rewrite norma mulrCA divff ?mulr1.
 Qed.
 
 (* standard trigonometric relations *)
@@ -461,7 +461,7 @@ Proof. by rewrite /tan sinN cosN mulNr. Qed.
 
 Lemma cos2_tan2 x : cos x != 0 -> 1 / (cos x) ^+ 2 = 1 + (tan x) ^+ 2.
 Proof.
-move=> cosx; rewrite /tan exprMn sin2cos2 mulrBl -exprMn divrr ?unitfE //.
+move=> cosx; rewrite /tan exprMn sin2cos2 mulrBl -exprMn divff//.
 by rewrite expr1n addrCA subrr addr0 div1r mul1r exprVn.
 Qed.
 
@@ -519,13 +519,14 @@ have [b1|b1] : {b = 1} + {b = - 1}.
   by apply/eqP; rewrite /pihalf a0 b1 expiNi eq_complex /= oppr0 2!eqxx.
 Qed.
 
-Definition piquarter : angle T := arg (Num.sqrt (2%:R^-1) +i* Num.sqrt (2%:R^-1))%C.
+Definition piquarter : angle T :=
+  arg (Num.sqrt (2%:R^-1) +i* Num.sqrt (2%:R^-1))%C.
 
 Lemma expi_piquarter :
   expi piquarter = (Num.sqrt (2%:R^-1) +i* Num.sqrt (2%:R^-1))%C.
 Proof.
 rewrite /piquarter argK // normc_def /= sqr_sqrtr ?invr_ge0 ?ler0n //.
-by rewrite -div1r -mulr2n -mulrnAl divrr ?unitfE ?pnatr_eq0 // sqrtr1.
+by rewrite -div1r -mulr2n -mulrnAl divff ?pnatr_eq0// sqrtr1.
 Qed.
 
 (*
@@ -735,7 +736,7 @@ rewrite mul1r invrM.
     abstract: x2D1.
     by rewrite addr_gt0 // ?ltr01 // exprn_even_gt0 //= invr_eq0 gt_eqF.
   by rewrite gt_eqF.
-by rewrite mulrA divrr // invrK mul1r.
+by rewrite mulrA divrr// invrK mul1r.
 Qed.
 
 Lemma atanKneg x : x < 0 -> tan (atan x) = x.
@@ -758,8 +759,8 @@ case/boolP : (x == 0) => [/eqP ->|x0].
 rewrite sin2cos2.
 apply/eqP; rewrite -eqr_opp opprB subr_eq; apply/eqP.
 rewrite -mulNr.
-have /divrr H : 1 + x ^+ 2 \in GRing.unit.
-  by rewrite unitfE gt_eqF // -(addr0 0) ltr_leD // ?ltr01 // sqr_ge0.
+have /divff H : 1 + x ^+ 2 != 0.
+  by rewrite gt_eqF // -(addr0 0) ltr_leD // ?ltr01 // sqr_ge0.
 rewrite -{2}H {H} addrC mulNr -mulrBl -invf_div -[LHS]invrK; congr (_ ^-1).
 rewrite -exprVn -div1r expr_div_n expr1n cos2_tan2.
   by rewrite gt_eqF // -Npi2pi2_openP atan_in.
@@ -873,7 +874,7 @@ Lemma half_angle0 : half_angle 0 = 0.
 Proof.
 apply val_inj => /=; rewrite /half_anglec; case: ifPn => /=; rewrite expi0 /=.
 2: by rewrite lexx.
-move=> _; rewrite subrr mul0r sqrtr0 divrr ?unitfE // ?complexr0 ?sqrtr1 //.
+move=> _; rewrite subrr mul0r sqrtr0 divff ?complexr0 ?sqrtr1//.
 by rewrite (_ : 1 + 1 = 2%:R) // pnatr_eq0.
 Qed.
 
@@ -882,7 +883,7 @@ Proof.
 apply val_inj => /=; rewrite /half_anglec; case: ifPn => /=; rewrite expipi /= oppr0.
 2: by rewrite lexx.
 move=> _; rewrite subrr mul0r sqrtr0 opprK expi_pihalf.
-rewrite (_ : 1 + 1 = 2%:R) // ?pnatr_eq0 divrr ?unitfE ?pnatr_eq0 //.
+rewrite (_ : 1 + 1 = 2%:R) // ?pnatr_eq0 divff ?pnatr_eq0//.
 by rewrite sqrtr1.
 Qed.
 
@@ -941,7 +942,7 @@ Lemma pihalf_is_half : pihalf _ = half_angle pi.
 Proof.
 rewrite /half_angle; apply val_inj => /=.
 rewrite /half_anglec expipi /= oppr0 lexx subrr mul0r sqrtr0 opprK.
-by rewrite -(@natrD _ 1 1) divrr ?unitfE ?pnatr_eq0 // sqrtr1 expi_pihalf.
+by rewrite -(@natrD _ 1 1) divff ?pnatr_eq0// sqrtr1 expi_pihalf.
 Qed.
 
 Lemma pi_pihalf : pi = pihalf T *+ 2.
@@ -990,10 +991,10 @@ rewrite sqrtrM ?subr_ge0//.
 case: (lerP 0 (cos (half_angle a))) => ca0.
   move: H2; rewrite ger0_norm // => ->.
   rewrite sqrtrM; first by rewrite -lerBDl add0r.
-  rewrite -mulf_div divrr ?unitfE ?sqrtr_eq0 -?ltNge ?invr_gt0 ?ltr0Sn // mulr1.
+  rewrite -mulf_div divff ?sqrtr_eq0 -?ltNge ?invr_gt0 ?ltr0Sn // mulr1.
   case/boolP : (cos a == 1) => [/eqP ca1|ca1]; first by rewrite ca1 subrr sqrtr0 2!mul0r.
-  rewrite -[LHS]mulr1 -{3}(@divrr _ (Num.sqrt (1 - cos a))).
-    by rewrite unitfE sqrtr_eq0 -ltNge subr_gt0 lt_neqAle ca1.
+  rewrite -[LHS]mulr1 -{3}(@divff _ (Num.sqrt (1 - cos a))).
+    by rewrite sqrtr_eq0 -ltNge subr_gt0 lt_neqAle ca1.
   rewrite mulf_div -sqrtrM ?subr_ge0//.
   rewrite -expr2 -sqrtrM; first by rewrite -lerBDl add0r.
   rewrite (mulrC (1 + cos a)) -subr_sqr expr1n.
@@ -1005,10 +1006,10 @@ move: (cos_half_angle a).
 rewrite ltr0_norm // => /eqP.
 rewrite eqr_oppLR => /eqP ->.
 rewrite invrN mulrN sqrtrM; first by rewrite -lerBDl add0r.
-rewrite -mulf_div divrr ?unitfE ?sqrtr_eq0 -?ltNge ?invr_gt0 ?ltr0Sn // mulr1.
+rewrite -mulf_div divff ?sqrtr_eq0 -?ltNge ?invr_gt0 ?ltr0Sn // mulr1.
 case/boolP : (cos a == 1) => [/eqP ca1|ca1]; first by rewrite ca1 subrr sqrtr0 2!mul0r oppr0.
-rewrite -[LHS]mulr1 -{3}(@divrr _ (Num.sqrt (1 - cos a))).
-  by rewrite unitfE sqrtr_eq0 -ltNge subr_gt0 lt_neqAle ca1.
+rewrite -[LHS]mulr1 -{3}(@divff _ (Num.sqrt (1 - cos a))).
+  by rewrite sqrtr_eq0 -ltNge subr_gt0 lt_neqAle ca1.
 rewrite mulNr mulf_div -sqrtrM ?subr_ge0//.
 rewrite -expr2 -sqrtrM; first by rewrite -lerBDl add0r.
 rewrite (mulrC (1 + cos a)) -subr_sqr expr1n.
@@ -1024,10 +1025,9 @@ case/boolP : (cos a == 1) => [/eqP /cos1_angle0 ->|ca1].
   by rewrite sin0 mul0r /tan half_angle0 sin0 mul0r.
 case/boolP : (a == pi) => [/eqP|] api.
   by rewrite api sinpi mul0r half_anglepi tan_pihalf.
-rewrite -[RHS]mulr1 -{2}(@divrr _ (1 - cos a)); first by rewrite unitfE subr_eq0 eq_sym.
+rewrite -[RHS]mulr1 -{2}(@divff _ (1 - cos a)); first by rewrite subr_eq0 eq_sym.
 rewrite mulf_div (mulrC (1 + cos a)) -subr_sqr expr1n -sin2cos2 expr2.
-rewrite -mulf_div divrr ?mul1r ?tan_half_angle //.
-rewrite unitfE.
+rewrite -mulf_div divff ?mul1r ?tan_half_angle //.
 apply: contra ca1 => /eqP/sin0_inv[->|/eqP]; first by rewrite cos0.
 by rewrite (negbTE api).
 Qed.
@@ -1036,8 +1036,8 @@ End half_angle.
 
 Lemma atan2_N1N1 (T : rcfType) : atan2 (- 1) (- 1) = - piquarter T *+ 3.
 Proof.
-rewrite /atan2 ltr0N1 ltrN10 ler0N1 divrr.
-  by rewrite unitfE eqr_oppLR oppr0 oner_neq0.
+rewrite /atan2 ltr0N1 ltrN10 ler0N1 divff.
+  by rewrite eqr_oppLR oppr0 oner_neq0.
 rewrite atan1 pi_piquarter -opprB -{2}(mulr1n (piquarter T)).
 by rewrite -mulrnBr // mulNrn.
 Qed.
@@ -1050,15 +1050,15 @@ Lemma sqrtr_sqrN2 (x : T) : x != 0 -> Num.sqrt (x ^- 2) = `|x|^-1.
 Proof.
 move=> x0.
 apply (@mulrI _ `|x|); first by rewrite unitfE normr_eq0.
-rewrite -{1}(sqrtr_sqr x) -sqrtrM ?sqr_ge0 // divrr ?unitfE ?normr_eq0//.
-by rewrite divrr ?sqrtr1 // unitfE sqrf_eq0.
+rewrite -{1}(sqrtr_sqr x) -sqrtrM ?sqr_ge0 // divff ?normr_eq0 ?sqrf_eq0//.
+by rewrite divff ?sqrtr1 ?normr_eq0.
 Qed.
 
 Lemma sqrtr_1sqr2 (x y : T) : Num.sqrt (x ^+ 2 + y ^+ 2) = 1 -> x != 0 ->
   Num.sqrt (1 + (y / x) ^+ 2) = `|x|^-1.
 Proof.
 move=> u1 k0.
-rewrite exprMn exprVn -(@divrr _ (x ^+ 2)) ?unitfE ?sqrf_eq0 //.
+rewrite exprMn exprVn -(@divff _ (x ^+ 2)) ?sqrf_eq0//.
 by rewrite -mulrDl sqrtrM ?u1 ?mul1r ?sqrtr_sqrN2 // addr_ge0// sqr_ge0.
 Qed.
 
@@ -1089,8 +1089,8 @@ Lemma inv_yarc (x : T) : `| x | < 1 -> (yarc x)^-1 = Num.sqrt (1 - x ^+ 2)^-1.
 Proof.
 move=> x1.
 apply (@mulrI _ (yarc x)); first by rewrite unitfE yarc_neq0.
-rewrite divrr ?unitfE ?yarc_neq0// -sqrtrM ?ltW // ?N1x2_gt0//.
-by rewrite divrr ?sqrtr1 // unitfE gt_eqF // N1x2_gt0.
+rewrite divff ?yarc_neq0// -sqrtrM ?ltW // ?N1x2_gt0//.
+by rewrite divff ?sqrtr1 // gt_eqF // N1x2_gt0.
 Qed.
 
 Lemma inv_yarc_gt0 (x : T) : `| x | < 1 -> 0 < (yarc x)^-1.
@@ -1118,7 +1118,7 @@ rewrite neq_lt => /orP[] y0.
   case: (lerP 0 x) => x0.
     rewrite atan2_ge0_lt0E // cosDpi ?eqxx // cos_atan mul1r expr_div_n.
     abstract: H.
-    rewrite -{1}(@divrr _ (y ^+ 2)); first by rewrite unitfE sqrf_eq0 lt_eqF.
+    rewrite -{1}(@divff _ (y ^+ 2)); first by rewrite sqrf_eq0 lt_eqF.
     rewrite -mulrDl sqrtrM ?addr_ge0 ?sqr_ge0//.
     rewrite sqrtr_sqrN2 ?lt_eqF // ltr0_norm // invrM.
       by rewrite unitfE sqrtr_eq0 -ltNge ltr_pwDl // ?sqr_ge0 // exprn_even_gt0 // orbC lt_eqF.
@@ -1127,9 +1127,9 @@ rewrite neq_lt => /orP[] y0.
   rewrite atan2_lt0_lt0E // -piNpi cosDpi ?eqxx ?orbT // cos_atan mul1r expr_div_n.
   exact: H.
 rewrite {1}atan2_x_gt0E // cos_atan mul1r.
-rewrite -{1}(@divrr _ (y ^+ 2)) ?unitfE ?sqrf_eq0 ?gt_eqF//.
+rewrite -{1}(@divff _ (y ^+ 2)) ?sqrf_eq0 ?gt_eqF//.
 rewrite expr_div_n -mulrDl sqrtrM ?addr_ge0 ?sqr_ge0//.
-rewrite sqrtr_sqrN2 ?gt_eqF // gtr0_norm // invrM ?invrK //.
+rewrite sqrtr_sqrN2 ?gt_eqF // gtr0_norm // invrM ?invrK//.
   by rewrite unitfE sqrtr_eq0 -ltNge ltr_pwDl // ?sqr_ge0 // exprn_gt0.
 by rewrite unitfE invr_neq0 // gt_eqF.
 Qed.
@@ -1156,7 +1156,7 @@ rewrite neq_lt => /orP[] y0.
   case: (lerP 0 x) => x0.
     rewrite atan2_ge0_lt0E // sinDpi ?eqxx // sin_atan expr_div_n.
     abstract: H.
-    rewrite -{1}(@divrr _ (y ^+ 2)) ?unitfE ?sqrf_eq0 ?lt_eqF//.
+    rewrite -{1}(@divff _ (y ^+ 2)) ?sqrf_eq0 ?lt_eqF//.
     rewrite -mulrDl sqrtrM ?addr_ge0 ?sqr_ge0//.
     rewrite sqrtr_sqrN2 ?lt_eqF // ltr0_norm // invrM.
       by rewrite unitfE sqrtr_eq0 -ltNge ltr_wpDr // ?sqr_ge0 // exprn_even_gt0 // orbC lt_eqF.
@@ -1166,7 +1166,7 @@ rewrite neq_lt => /orP[] y0.
   rewrite atan2_lt0_lt0E // -piNpi sinDpi ?eqxx ?orbT // sin_atan expr_div_n.
   exact: H.
 rewrite {1}atan2_x_gt0E // sin_atan.
-rewrite -{1}(@divrr _ (y ^+ 2)) ?unitfE ?sqrf_eq0 ?gt_eqF//.
+rewrite -{1}(@divff _ (y ^+ 2)) ?sqrf_eq0 ?gt_eqF//.
 rewrite expr_div_n -mulrDl sqrtrM ?addr_ge0 ?sqr_ge0//.
 rewrite sqrtr_sqrN2 ?gt_eqF // gtr0_norm // invrM.
   by rewrite unitfE sqrtr_eq0 -ltNge ltr_wpDr // ?sqr_ge0 // exprn_gt0.

--- a/angle.v
+++ b/angle.v
@@ -83,7 +83,7 @@ apply/eqP; rewrite eq_le !rootC_Re_max ?exprM ?rootCK ?Im_rootC_ge0 //.
 apply: eqC_semipolar; first 2 last.
 - rewrite mulr_ge0 ?Im_rootC_ge0 //. admit.
 - by rewrite normrX !norm_rootC hwlog_x_ge0 // rootCK.
-apply/eqP; rewrite eq_le rootC_Re_max -?exprM ?rootCK //=; last first.
+apply/eqP; rewrite eq_le rootC_Re_max -?exprM ?rootCK //=.
   admit.
 admit.
 Abort.
@@ -123,16 +123,14 @@ Definition arg (x : T[i]) : angle :=
 Lemma argZ x (k : T) : 0 < k -> arg (k %:C%C * x) = arg x.
 Proof.
 move=> k0; rewrite /arg; congr (insubd _ _).
-rewrite normrM gtr0_norm; last by rewrite ltcR.
-rewrite -mulf_div divff ?mul1r //.
-by rewrite lt0r_neq0 // ltcR.
+by rewrite normrM gtr0_norm ?ltcR// -mulf_div divff ?mul1r // lt0r_neq0 // ltcR.
 Qed.
 
 Lemma argZ_neg x (k : T) : k < 0 -> arg (k %:C%C * x) = arg (- x).
 Proof.
 move=> k0; rewrite /arg; congr (insubd _ _).
-rewrite normrM ltr0_norm; last by rewrite ltcR.
-rewrite -mulf_div invrN mulrN divff ?mul1r; last by rewrite ltr0_neq0 // ltcR.
+rewrite normrM ltr0_norm ?ltcR//.
+rewrite -mulf_div invrN mulrN divff ?mul1r; first by rewrite ltr0_neq0 // ltcR.
 by rewrite mulNr mul1r normrN mulNr.
 Qed.
 
@@ -150,9 +148,9 @@ Qed.
 
 Lemma expi_conjc (a : T[i]) : a != 0 -> (expi (arg a))^-1 = expi (arg a^*).
 Proof.
-case: a => a b a0 /=; rewrite expi_arg // expi_arg //; last first.
-  apply: contra a0 => a0; by rewrite -conjc_eq0.
-rewrite invc_norm (_ : `| _ | = 1); last first.
+case: a => a b a0 /=; rewrite expi_arg // expi_arg.
+  by apply: contra a0 => a0; rewrite -conjc_eq0.
+rewrite invc_norm (_ : `| _ | = 1).
   by rewrite normrM normrV ?unitfE ?normr_eq0 // normr_id divrr // unitfE normr_eq0.
 rewrite exprnN exp1rz mul1r. simpc. by rewrite /= sqrrN.
 Qed.
@@ -188,7 +186,7 @@ Proof. by rewrite /add_angle argK ?normr1 ?mul1r ?expiK. Qed.
 
 Lemma add_Nangle x : add_angle (opp_angle x) x = arg 1.
 Proof.
-rewrite /add_angle /opp_angle argK; first by rewrite mulVr // expi_is_unit.
+rewrite /add_angle /opp_angle argK; last by rewrite mulVr // expi_is_unit.
 by rewrite normrV ?expi_is_unit // normr_expi invr1.
 Qed.
 
@@ -257,7 +255,7 @@ Qed.
 Lemma cosN a : cos (- a) = cos a.
 Proof.
 case: a => -[a b] ab; rewrite opp_angleE /cos /opp_angle /=.
-rewrite invc_norm (eqP ab) expr1n invr1 mul1r expi_arg; last first.
+rewrite invc_norm (eqP ab) expr1n invr1 mul1r expi_arg.
   by rewrite conjc_eq0 -normr_eq0 (eqP ab) oner_eq0.
 by rewrite normcJ (eqP ab) divr1.
 Qed.
@@ -273,7 +271,7 @@ Proof. by rewrite /sin /pi argK /= ?oppr0 // normrN normr1. Qed.
 Lemma sinN a : sin (- a) = - sin a.
 Proof.
 case: a => -[a b] ab; rewrite opp_angleE /sin /opp_angle /=.
-rewrite invc_norm (eqP ab) expr1n invr1 mul1r expi_arg; last first.
+rewrite invc_norm (eqP ab) expr1n invr1 mul1r expi_arg.
   by rewrite conjc_eq0 -normr_eq0 (eqP ab) oner_eq0.
 by rewrite normcJ (eqP ab) divr1.
 Qed.
@@ -293,7 +291,7 @@ Proof.
 move=> v1.
 have {}v1 : (`| x +i* y | = 1)%C by rewrite normc_def /= v1 sqrtr1.
 exists (arg (x +i* y)%C).
-rewrite /cos /sin expi_arg //; last by rewrite -normr_eq0 v1 oner_neq0.
+rewrite /cos /sin expi_arg //; first by rewrite -normr_eq0 v1 oner_neq0.
 by rewrite v1 divr1.
 Qed.
 
@@ -320,7 +318,7 @@ Qed.
 Lemma pi_neq0 : pi != 0 :> angle T.
 Proof.
 apply/eqP => /(congr1 expi).
-rewrite argK ?expi0; last by rewrite normrN normr1.
+rewrite argK ?expi0; first by rewrite normrN normr1.
 by move/eqP; rewrite eq_sym -subr_eq0 opprK (_ : 1 + 1 = 2%:R) // pnatr_eq0.
 Qed.
 
@@ -329,7 +327,7 @@ Proof. by rewrite argK // normc_def /= expr0n expr1n add0r sqrtr1. Qed.
 
 Lemma expiNi : expi (- arg 'i) = -'i :> T[i].
 Proof.
-rewrite expi_cos_sin sinN cosN /cos /sin expi_arg; last first.
+rewrite expi_cos_sin sinN cosN /cos /sin expi_arg.
   by rewrite -normr_eq0 normci oner_neq0.
 rewrite normci divr1 /=; apply/eqP; by rewrite eq_complex /= oppr0 2!eqxx.
 Qed.
@@ -347,14 +345,14 @@ Proof. by apply expi_inj; rewrite expiNpi expipi. Qed.
 Lemma arg0_inv (x : T[i]) y : y != 0 -> `|x| = y -> arg x = 0 -> x = y.
 Proof.
 move=> y0; case: x => x1 x2 norma H.
-rewrite -(mulr1 y) -expi0 -H expi_arg; last by rewrite -normr_eq0 norma.
+rewrite -(mulr1 y) -expi0 -H expi_arg; first by rewrite -normr_eq0 norma.
 by rewrite norma mulrCA divrr // mulr1.
 Qed.
 
 Lemma argpi_inv (x : T[i]) y : y != 0 -> `|x| = y -> arg x = pi -> x = - y.
 Proof.
 move=> y0; case: x => x1 x2 norma H.
-rewrite -(mulrN1 y) -expipi -H expi_arg; last by rewrite -normr_eq0 norma.
+rewrite -(mulrN1 y) -expipi -H expi_arg; first by rewrite -normr_eq0 norma.
 by rewrite norma mulrCA divrr // mulr1.
 Qed.
 
@@ -395,9 +393,8 @@ Proof. by rewrite sinD cosN sinN mulrN. Qed.
 
 Lemma abs_sin a : `| sin a | = Num.sqrt (1 - cos a ^+ 2).
 Proof.
-apply/eqP; rewrite -(@eqrXn2 _ 2) //; last by rewrite sqrtr_ge0.
-rewrite -normrX ger0_norm; last by rewrite sqr_ge0.
-rewrite sqr_sqrtr; last first.
+apply/eqP; rewrite -(@eqrXn2 _ 2) ?sqrtr_ge0//.
+rewrite -normrX ger0_norm ?sqr_ge0// sqr_sqrtr.
   by rewrite lterBDr add0r -sqr_normr exprn_ilte1 // cos_max.
 by rewrite -subr_eq opprK addrC cos2Dsin2.
 Qed.
@@ -480,16 +477,16 @@ Lemma sin_pihalf : sin pihalf = 1.
 Proof.
 have i1 : `|'i| = 1 :> T[i] by rewrite normc_def /= expr0n add0r expr1n sqrtr1.
 rewrite /sin /pihalf expi_arg //.
-by rewrite i1 divr1.
 by rewrite -normr_eq0 i1 oner_neq0.
+by rewrite i1 divr1.
 Qed.
 
 Lemma cos_pihalf : cos pihalf = 0.
 Proof.
 have i1 : `|'i| = 1 :> T[i] by rewrite normc_def /= expr0n add0r expr1n sqrtr1.
 rewrite /cos /pihalf expi_arg //.
-by rewrite i1 divr1.
 by rewrite -normr_eq0 i1 oner_neq0.
+by rewrite i1 divr1.
 Qed.
 
 Lemma tan_pihalf : tan pihalf = 0.
@@ -574,15 +571,15 @@ Proof.
 rewrite /atan eqr_oppLR oppr0.
 case: ifPn => [|x0]; first by rewrite oppr0.
 rewrite -argc.
-  congr arg; apply/eqP.
-  rewrite sgzN mulrNz /= eq_complex /=.
   move: x0; rewrite neq_lt => /orP [] x0.
-    by rewrite ltr0_sgz // 2!mulrN1z opprK /= invrN opprK 2!eqxx.
-  by rewrite gtr0_sgz // 2!mulr1z /= invrN opprK 2!eqxx.
+    rewrite ltr0_sgz // -?oppr_gt0 ?opprK // mulrN1z eq_complex /= negb_and orbC.
+    by rewrite eqr_oppLR oppr0 oner_neq0.
+  by rewrite gtr0_sgz ?oppr_gt0 // mulr1z eq_complex /= negb_and oner_neq0 orbC.
+congr arg; apply/eqP.
+rewrite sgzN mulrNz /= eq_complex /=.
 move: x0; rewrite neq_lt => /orP [] x0.
-  rewrite ltr0_sgz // -?oppr_gt0 ?opprK // mulrN1z eq_complex /= negb_and orbC.
-  by rewrite eqr_oppLR oppr0 oner_neq0.
-by rewrite gtr0_sgz ?oppr_gt0 // mulr1z eq_complex /= negb_and oner_neq0 orbC.
+  by rewrite ltr0_sgz // 2!mulrN1z opprK /= invrN opprK 2!eqxx.
+by rewrite gtr0_sgz // 2!mulr1z /= invrN opprK 2!eqxx.
 Qed.
 
 Definition atan2 x y :=
@@ -634,7 +631,7 @@ Proof. by rewrite inE. Qed.
 
 Lemma acosK (r : T) : -1 <= r <= 1 -> cos (acos r) = r.
 Proof.
-move=> rdom; rewrite /acos /cos argK // normc_def /= sqr_sqrtr; last first.
+move=> rdom; rewrite /acos /cos argK // normc_def /= sqr_sqrtr.
   by rewrite subr_ge0 -ler_sqrt // ?ltr01 // sqrtr1 sqrtr_sqr ler_norml.
 by rewrite addrC subrK sqrtr1.
 Qed.
@@ -682,7 +679,7 @@ Lemma sinK (x : angle T) : 0 <= cos x (* TODO: define Npi2pi2_closed? *) ->
   asin (sin x) = x.
 Proof.
 case: x => /= -[x y] x1 cosx1; apply/val_inj/eqP => /=.
-rewrite eq_complex /asin /sin argK /= ?eqxx ?andbT; last first.
+rewrite eq_complex /asin /sin argK /= ?eqxx ?andbT.
   rewrite {cosx1}.
   rewrite normc_def /= sqr_sqrtr ?subrK ?sqrtr1 // subr_ge0.
   move: x1; rewrite normc_def eq_complex eqxx andbT /=.
@@ -698,7 +695,7 @@ Qed.
 
 Lemma asinK r : -1 <= r <= 1 -> sin (asin r) = r.
 Proof.
-move=> rdom; rewrite /sin /asin argK // normc_def /= sqr_sqrtr; last first.
+move=> rdom; rewrite /sin /asin argK // normc_def /= sqr_sqrtr.
   by rewrite subr_ge0 -ler_sqrt // ?ltr01 // sqrtr1 sqrtr_sqr ler_norml.
 by rewrite subrK sqrtr1.
 Qed.
@@ -709,28 +706,28 @@ case/boolP : (x == 0) => [/eqP ->|x0].
   by rewrite atan0 inE cos0 ltr01.
 rewrite Npi2pi2_openP /atan (negbTE x0) /cos => [:myRe0].
 rewrite expi_arg.
-  rewrite normc_def => [:myltr0].
-  rewrite Re_scale.
-    rewrite divr_gt0 //.
-      abstract: myRe0.
-      move/lt_total : x0 => /orP [] x0; last by rewrite gtr0_sgz //= invr_gt0.
-      by rewrite ltr0_sgz //= ltrNr oppr0 invr_lt0.
-    abstract: myltr0.
-    rewrite -ltcR -normc_def normr_gt0 eq_complex /= negb_and.
-    move/lt_total : x0 => /orP [] x0; last by rewrite gtr0_sgz //= invr_eq0 gt_eqF.
-    by rewrite ltr0_sgz //= eqr_oppLR oppr0 invr_eq0 lt_eqF.
-  by rewrite gt_eqF.
-by rewrite eq_complex /= negb_and gt_eqF.
+  by rewrite mulrz_eq0 negb_or sgz_eq0 x0 /= eq_complex /= negb_and oner_neq0 orbT.
+rewrite normc_def => [:myltr0].
+rewrite Re_scale; last first.
+  rewrite divr_gt0 //.
+    abstract: myRe0.
+    move/lt_total : x0 => /orP [] x0; last by rewrite gtr0_sgz //= invr_gt0.
+    by rewrite ltr0_sgz //= ltrNr oppr0 invr_lt0.
+  abstract: myltr0.
+  rewrite -ltcR -normc_def normr_gt0 eq_complex /= negb_and.
+  move/lt_total : x0 => /orP [] x0; last by rewrite gtr0_sgz //= invr_eq0 gt_eqF.
+  by rewrite ltr0_sgz //= eqr_oppLR oppr0 invr_eq0 lt_eqF.
+by rewrite gt_eqF.
 Qed.
 
 Lemma atanKpos x : 0 < x -> tan (atan x) = x.
 Proof.
 move=> x0; rewrite /atan gt_eqF // gtr0_sgz // mulr1z /tan /sin /cos.
-rewrite expi_arg /=; last by rewrite eq_complex /= negb_and oner_neq0 orbT.
+rewrite expi_arg /=; first by rewrite eq_complex /= negb_and oner_neq0 orbT.
 rewrite mul0r oppr0 mulr0 add0r mulr0 subr0 expr0n addr0 expr1n.
-rewrite sqr_sqrtr; last by rewrite addr_ge0 // ?ler01 // sqr_ge0.
+rewrite sqr_sqrtr; first by rewrite addr_ge0 // ?ler01 // sqr_ge0.
 set y := Num.sqrt _ / _; move=> [:yunit].
-rewrite mul1r invrM; last 2 first.
+rewrite mul1r invrM.
   by rewrite unitrV unitfE gt_eqF.
   abstract: yunit.
   rewrite unitfE /y mulf_eq0 negb_or sqrtr_eq0 -ltNge invr_eq0.
@@ -765,22 +762,22 @@ have /divrr H : 1 + x ^+ 2 \in GRing.unit.
   by rewrite unitfE gt_eqF // -(addr0 0) ltr_leD // ?ltr01 // sqr_ge0.
 rewrite -{2}H {H} addrC mulNr -mulrBl -invf_div -[LHS]invrK; congr (_ ^-1).
 rewrite -exprVn -div1r expr_div_n expr1n cos2_tan2.
-  by rewrite atanK addrK divr1.
-by rewrite gt_eqF // -Npi2pi2_openP atan_in.
+  by rewrite gt_eqF // -Npi2pi2_openP atan_in.
+by rewrite atanK addrK divr1.
 Qed.
 
 Lemma sin_atan_ltr0 (x : T) : x < 0 -> sin (atan x) < 0.
 Proof.
 move=> x0.
 rewrite /sin /atan lt_eqF // ltr0_sgz // mulrN1z /= expi_arg //=.
-  rewrite expr0n addr0 mul0r oppr0 mulr0 add0r.
-  rewrite sqr_sqrtr; last by rewrite addr_ge0 // sqr_ge0.
-  rewrite pmulr_llt0; first by rewrite oppr_lt0 ltr01.
-  rewrite (sqrrN 1) expr1n divr_gt0 //.
-    rewrite sqrtr_gt0 addr_gt0 // ?ltr01 //.
-    by rewrite exprn_gt0 // oppr_gt0 invr_lt0.
-  by rewrite addr_gt0 // ?ltr01 // exprn_gt0 // oppr_gt0 invr_lt0.
-by rewrite eq_complex /= negb_and /= orbC eqr_oppLR oppr0 oner_eq0.
+  by rewrite eq_complex /= negb_and /= orbC eqr_oppLR oppr0 oner_eq0.
+rewrite expr0n addr0 mul0r oppr0 mulr0 add0r.
+rewrite sqr_sqrtr; first by rewrite addr_ge0 // sqr_ge0.
+rewrite pmulr_llt0; last by rewrite oppr_lt0 ltr01.
+rewrite (sqrrN 1) expr1n divr_gt0 //.
+  rewrite sqrtr_gt0 addr_gt0 // ?ltr01 //.
+  by rewrite exprn_gt0 // oppr_gt0 invr_lt0.
+by rewrite addr_gt0 // ?ltr01 // exprn_gt0 // oppr_gt0 invr_lt0.
 Qed.
 
 Lemma sin_atan_gtr0 (x : T) : 0 < x -> 0 < sin (atan x).
@@ -795,11 +792,11 @@ apply/eqP.
 case/boolP : (x == 0) => [/eqP ->|].
   by rewrite atan0 sin0 mul0r.
 move/lt_total => /orP [] x0.
-  rewrite -eqr_opp -(@eqrXn2 _ 2) //; last 2 first.
+  rewrite -eqr_opp -(@eqrXn2 _ 2) //.
     move/sin_atan_ltr0 : x0; by rewrite oppr_ge0 => /ltW.
     by rewrite -mulNr divr_ge0 // ?sqrtr_ge0 // oppr_ge0 ltW.
   by rewrite 2!sqrrN sqr_sin_atan exprMn exprVn sqr_sqrtr // addr_ge0 // ?ler01 // sqr_ge0.
-rewrite -(@eqrXn2 _ 2) //; last 2 first.
+rewrite -(@eqrXn2 _ 2) //.
   by rewrite ltW // sin_atan_gtr0.
   by rewrite mulr_ge0 // ?invr_ge0 ?sqrtr_ge0 // ltW.
 by rewrite sqr_sin_atan exprMn exprVn sqr_sqrtr // addr_ge0 // ?ler01 // sqr_ge0.
@@ -808,8 +805,8 @@ Qed.
 Lemma sin_acos x : `|x| <= 1 -> sin (acos x) = Num.sqrt (1 - x ^+ 2).
 Proof.
 move=> Nx_le1; rewrite /sin /acos argK //; simpc; rewrite sqr_sqrtr.
-  by rewrite addrC addrNK sqrtr1.
-by rewrite subr_ge0 -[_ ^+ _]real_normK ?num_real // exprn_ile1.
+  by rewrite subr_ge0 -[_ ^+ _]real_normK ?num_real // exprn_ile1.
+by rewrite addrC addrNK sqrtr1.
 Qed.
 
 Lemma cos_asin (x : T) : `| x | < 1 -> cos (asin x) = Num.sqrt (1 - x ^+ 2).
@@ -858,14 +855,14 @@ Proof.
 move=> x1.
 rewrite /half_anglec.
 case: ifP => a0.
-  rewrite normc_def /= sqr_sqrtr; last first.
+  rewrite normc_def /= sqr_sqrtr.
     by rewrite divr_ge0 // ?ler0n // Re_half_anglec.
-  rewrite sqr_sqrtr; last first.
+  rewrite sqr_sqrtr.
     by rewrite divr_ge0 // ?ler0n // subr_ge0 Im_half_anglec.
   by rewrite mulrC (mulrC (1 - complex.Re x)) -mulrDr addrCA addrK -mulr2n mulVr ?pnatf_unit // sqrtr1.
-rewrite normc_def /= sqr_sqrtr; last first.
+rewrite normc_def /= sqr_sqrtr.
   by rewrite divr_ge0 // ?ler0n // subr_ge0 Im_half_anglec.
-rewrite sqrrN sqr_sqrtr; last first.
+rewrite sqrrN sqr_sqrtr.
   by rewrite divr_ge0 // ?ler0n // Re_half_anglec.
 by rewrite mulrC (mulrC (1 - complex.Re x)) -mulrDr addrCA addrK -mulr2n mulVr ?pnatf_unit // sqrtr1.
 Qed.
@@ -899,42 +896,42 @@ Lemma halfP a : half_angle a + half_angle a = a.
 Proof.
 apply/eqP.
 rewrite eq_angle; apply/andP; split.
-  rewrite /cos /= add_angleE /add_angle /half_angle /= argK; last first.
+  rewrite /cos /= add_angleE /add_angle /half_angle /= argK.
     by rewrite normrM (eqP (norm_half_anglec (normr_expi _))) mulr1.
   rewrite /half_anglec. simpc. rewrite /=.
   move=> [:tmp].
   case: ifP => a0 /=.
     abstract: tmp.
-    rewrite -2!expr2 sqr_sqrtr; last first.
+    rewrite -2!expr2 sqr_sqrtr.
       by rewrite divr_ge0 // ?Re_half_anglec // ?normr_expi // ler0n.
-    rewrite sqr_sqrtr; last first.
+    rewrite sqr_sqrtr.
       by rewrite divr_ge0 // ?ler0n // subr_ge0 Im_half_anglec // normr_expi.
     rewrite mulrC (mulrC (_ - _)) -mulrBr opprB addrC addrA subrK -mulr2n.
     by rewrite -(mulr_natl (complex.Re _)) mulrA mulVr ?pnatf_unit // mul1r eqxx.
   rewrite mulNr mulrN opprK; exact: tmp.
-rewrite /sin /= add_angleE /add_angle /half_angle /= argK; last first.
+rewrite /sin /= add_angleE /add_angle /half_angle /= argK.
   by rewrite normrM (eqP (norm_half_anglec (normr_expi _))) mulr1.
 rewrite /half_anglec. simpc. rewrite /=.
 case: ifPn => a0 /=.
   rewrite mulrC -mulr2n.
-  rewrite (@sqrtrM _ (1 - complex.Re a)); last by rewrite subr_ge0 Im_half_anglec // normr_expi.
-  rewrite (@sqrtrM _ (1 + complex.Re a)); last by rewrite Re_half_anglec // normr_expi.
+  rewrite (@sqrtrM _ (1 - complex.Re a)); first by rewrite subr_ge0 Im_half_anglec // normr_expi.
+  rewrite (@sqrtrM _ (1 + complex.Re a)); first by rewrite Re_half_anglec // normr_expi.
   rewrite mulrCA -mulrA -(sqrtrM 2^-1) ?invr_ge0//.
   rewrite -expr2 sqrtr_sqr normfV ger0_norm// -[eqbLHS](mulr_natr _ 2).
   rewrite -2!mulrA mulVf ?pnatr_eq0// mulr1.
-  rewrite mulrC -sqrtrM; last by rewrite subr_ge0 Im_half_anglec // normr_expi.
+  rewrite mulrC -sqrtrM; first by rewrite subr_ge0 Im_half_anglec // normr_expi.
   rewrite -subr_sqr expr1n.
-  rewrite -(@eqrXn2 _ 2%N) //; last by rewrite sqrtr_ge0.
+  rewrite -(@eqrXn2 _ 2%N) //; first by rewrite sqrtr_ge0.
   by rewrite -sin2cos2 sqr_sqrtr // sqr_ge0.
 rewrite mulrN mulNr -opprD eqr_oppLR.
 rewrite mulrC -mulr2n.
-rewrite (@sqrtrM _ (1 - complex.Re a)); last by rewrite subr_ge0 Im_half_anglec // normr_expi.
-rewrite (@sqrtrM _ (1 + complex.Re a)); last by rewrite Re_half_anglec // normr_expi.
+rewrite (@sqrtrM _ (1 - complex.Re a)); first by rewrite subr_ge0 Im_half_anglec // normr_expi.
+rewrite (@sqrtrM _ (1 + complex.Re a)); first by rewrite Re_half_anglec // normr_expi.
 rewrite mulrAC -2!mulrA -sqrtrM ?invr_ge0//.
 rewrite -expr2 sqrtr_sqr normfV ger0_norm// mulrA -[eqbLHS]mulr_natr -!mulrA mulVf ?pnatr_eq0// mulr1.
-rewrite -sqrtrM; last by rewrite subr_ge0 Im_half_anglec // normr_expi.
+rewrite -sqrtrM; first by rewrite subr_ge0 Im_half_anglec // normr_expi.
 rewrite -subr_sqr expr1n.
-rewrite -(@eqrXn2 _ 2%N) //; last 2 first.
+rewrite -(@eqrXn2 _ 2%N) //.
   by rewrite sqrtr_ge0.
   by rewrite ltW // oppr_gt0 ltNge.
 by rewrite -sin2cos2 sqrrN sqr_sqrtr // sqr_ge0.
@@ -989,35 +986,34 @@ have H3 : cos a <= 1 by move: (@ler_norml _ (cos a) 1); rewrite cos_max => /esym
 have H4 : -1 <= cos a by move: (@ler_norml _ (cos a) 1); rewrite cos_max => /esym/andP[].
 move: (sin_half_angle_ge0 a) => sa0.
 move: H1; rewrite ger0_norm // => ->.
-rewrite sqrtrM; last by rewrite subr_ge0.
+rewrite sqrtrM ?subr_ge0//.
 case: (lerP 0 (cos (half_angle a))) => ca0.
   move: H2; rewrite ger0_norm // => ->.
-  rewrite sqrtrM; last by rewrite -lerBDl add0r.
+  rewrite sqrtrM; first by rewrite -lerBDl add0r.
   rewrite -mulf_div divrr ?unitfE ?sqrtr_eq0 -?ltNge ?invr_gt0 ?ltr0Sn // mulr1.
   case/boolP : (cos a == 1) => [/eqP ca1|ca1]; first by rewrite ca1 subrr sqrtr0 2!mul0r.
-  rewrite -[LHS]mulr1 -{3}(@divrr _ (Num.sqrt (1 - cos a))); last first.
+  rewrite -[LHS]mulr1 -{3}(@divrr _ (Num.sqrt (1 - cos a))).
     by rewrite unitfE sqrtr_eq0 -ltNge subr_gt0 lt_neqAle ca1.
-  rewrite mulf_div -sqrtrM; last by rewrite subr_ge0.
-  rewrite -expr2 -sqrtrM; last by rewrite -lerBDl add0r.
+  rewrite mulf_div -sqrtrM ?subr_ge0//.
+  rewrite -expr2 -sqrtrM; first by rewrite -lerBDl add0r.
   rewrite (mulrC (1 + cos a)) -subr_sqr expr1n.
   rewrite sqrtr_sqr -sin2cos2 sqrtr_sqr.
-  rewrite ger0_norm; last by rewrite subr_ge0.
+  rewrite ger0_norm ?subr_ge0//.
   rewrite ger0_norm // -(halfP a) sinD mulrC -mulr2n -mulr_natl.
   by rewrite mulr_ge0 // ?ler0n // mulr_ge0.
 move: (cos_half_angle a).
 rewrite ltr0_norm // => /eqP.
 rewrite eqr_oppLR => /eqP ->.
-rewrite invrN mulrN sqrtrM; last by rewrite -lerBDl add0r.
+rewrite invrN mulrN sqrtrM; first by rewrite -lerBDl add0r.
 rewrite -mulf_div divrr ?unitfE ?sqrtr_eq0 -?ltNge ?invr_gt0 ?ltr0Sn // mulr1.
 case/boolP : (cos a == 1) => [/eqP ca1|ca1]; first by rewrite ca1 subrr sqrtr0 2!mul0r oppr0.
-rewrite -[LHS]mulr1 -{3}(@divrr _ (Num.sqrt (1 - cos a))); last first.
+rewrite -[LHS]mulr1 -{3}(@divrr _ (Num.sqrt (1 - cos a))).
   by rewrite unitfE sqrtr_eq0 -ltNge subr_gt0 lt_neqAle ca1.
-rewrite mulNr mulf_div -sqrtrM; last by rewrite subr_ge0.
-rewrite -expr2 -sqrtrM; last by rewrite -lerBDl add0r.
+rewrite mulNr mulf_div -sqrtrM ?subr_ge0//.
+rewrite -expr2 -sqrtrM; first by rewrite -lerBDl add0r.
 rewrite (mulrC (1 + cos a)) -subr_sqr expr1n.
 rewrite sqrtr_sqr -sin2cos2 sqrtr_sqr.
-rewrite ger0_norm; last by rewrite subr_ge0.
-rewrite ler0_norm //; last first.
+rewrite ger0_norm ?subr_ge0// ler0_norm //.
   by rewrite -(halfP a) sinD mulrC -mulr2n -mulr_natl pmulr_rle0 ?ltr0n // nmulr_rle0.
 by rewrite invrN mulrN opprK.
 Qed.
@@ -1028,7 +1024,7 @@ case/boolP : (cos a == 1) => [/eqP /cos1_angle0 ->|ca1].
   by rewrite sin0 mul0r /tan half_angle0 sin0 mul0r.
 case/boolP : (a == pi) => [/eqP|] api.
   by rewrite api sinpi mul0r half_anglepi tan_pihalf.
-rewrite -[RHS]mulr1 -{2}(@divrr _ (1 - cos a)); last by rewrite unitfE subr_eq0 eq_sym.
+rewrite -[RHS]mulr1 -{2}(@divrr _ (1 - cos a)); first by rewrite unitfE subr_eq0 eq_sym.
 rewrite mulf_div (mulrC (1 + cos a)) -subr_sqr expr1n -sin2cos2 expr2.
 rewrite -mulf_div divrr ?mul1r ?tan_half_angle //.
 rewrite unitfE.
@@ -1040,7 +1036,7 @@ End half_angle.
 
 Lemma atan2_N1N1 (T : rcfType) : atan2 (- 1) (- 1) = - piquarter T *+ 3.
 Proof.
-rewrite /atan2 ltr0N1 ltrN10 ler0N1 divrr; last first.
+rewrite /atan2 ltr0N1 ltrN10 ler0N1 divrr.
   by rewrite unitfE eqr_oppLR oppr0 oner_neq0.
 rewrite atan1 pi_piquarter -opprB -{2}(mulr1n (piquarter T)).
 by rewrite -mulrnBr // mulNrn.
@@ -1054,7 +1050,7 @@ Lemma sqrtr_sqrN2 (x : T) : x != 0 -> Num.sqrt (x ^- 2) = `|x|^-1.
 Proof.
 move=> x0.
 apply (@mulrI _ `|x|); first by rewrite unitfE normr_eq0.
-rewrite -{1}(sqrtr_sqr x) -sqrtrM ?sqr_ge0 // divrr; last by rewrite unitfE normr_eq0.
+rewrite -{1}(sqrtr_sqr x) -sqrtrM ?sqr_ge0 // divrr ?unitfE ?normr_eq0//.
 by rewrite divrr ?sqrtr1 // unitfE sqrf_eq0.
 Qed.
 
@@ -1093,8 +1089,7 @@ Lemma inv_yarc (x : T) : `| x | < 1 -> (yarc x)^-1 = Num.sqrt (1 - x ^+ 2)^-1.
 Proof.
 move=> x1.
 apply (@mulrI _ (yarc x)); first by rewrite unitfE yarc_neq0.
-rewrite divrr; last by rewrite unitfE yarc_neq0.
-rewrite -sqrtrM; last by rewrite ltW // N1x2_gt0.
+rewrite divrr ?unitfE ?yarc_neq0// -sqrtrM ?ltW // ?N1x2_gt0//.
 by rewrite divrr ?sqrtr1 // unitfE gt_eqF // N1x2_gt0.
 Qed.
 
@@ -1123,19 +1118,19 @@ rewrite neq_lt => /orP[] y0.
   case: (lerP 0 x) => x0.
     rewrite atan2_ge0_lt0E // cosDpi ?eqxx // cos_atan mul1r expr_div_n.
     abstract: H.
-    rewrite -{1}(@divrr _ (y ^+ 2)); last by rewrite unitfE sqrf_eq0 lt_eqF.
-    rewrite -mulrDl sqrtrM; last by rewrite addr_ge0 // sqr_ge0.
-    rewrite sqrtr_sqrN2 ?lt_eqF // ltr0_norm // invrM; last 2 first.
+    rewrite -{1}(@divrr _ (y ^+ 2)); first by rewrite unitfE sqrf_eq0 lt_eqF.
+    rewrite -mulrDl sqrtrM ?addr_ge0 ?sqr_ge0//.
+    rewrite sqrtr_sqrN2 ?lt_eqF // ltr0_norm // invrM.
       by rewrite unitfE sqrtr_eq0 -ltNge ltr_pwDl // ?sqr_ge0 // exprn_even_gt0 // orbC lt_eqF.
       by rewrite unitfE invr_eq0 eqr_oppLR oppr0 lt_eqF.
     by rewrite !invrN invrK mulNr opprK.
   rewrite atan2_lt0_lt0E // -piNpi cosDpi ?eqxx ?orbT // cos_atan mul1r expr_div_n.
   exact: H.
 rewrite {1}atan2_x_gt0E // cos_atan mul1r.
-rewrite -{1}(@divrr _ (y ^+ 2)); last by rewrite unitfE sqrf_eq0 gt_eqF.
-rewrite expr_div_n -mulrDl sqrtrM; last by rewrite addr_ge0 // sqr_ge0.
+rewrite -{1}(@divrr _ (y ^+ 2)) ?unitfE ?sqrf_eq0 ?gt_eqF//.
+rewrite expr_div_n -mulrDl sqrtrM ?addr_ge0 ?sqr_ge0//.
 rewrite sqrtr_sqrN2 ?gt_eqF // gtr0_norm // invrM ?invrK //.
-by rewrite unitfE sqrtr_eq0 -ltNge ltr_pwDl // ?sqr_ge0 // exprn_gt0.
+  by rewrite unitfE sqrtr_eq0 -ltNge ltr_pwDl // ?sqr_ge0 // exprn_gt0.
 by rewrite unitfE invr_neq0 // gt_eqF.
 Qed.
 
@@ -1161,9 +1156,9 @@ rewrite neq_lt => /orP[] y0.
   case: (lerP 0 x) => x0.
     rewrite atan2_ge0_lt0E // sinDpi ?eqxx // sin_atan expr_div_n.
     abstract: H.
-    rewrite -{1}(@divrr _ (y ^+ 2)); last by rewrite unitfE sqrf_eq0 lt_eqF.
-    rewrite -mulrDl sqrtrM; last by rewrite addr_ge0 // sqr_ge0.
-    rewrite sqrtr_sqrN2 ?lt_eqF // ltr0_norm // invrM; last 2 first.
+    rewrite -{1}(@divrr _ (y ^+ 2)) ?unitfE ?sqrf_eq0 ?lt_eqF//.
+    rewrite -mulrDl sqrtrM ?addr_ge0 ?sqr_ge0//.
+    rewrite sqrtr_sqrN2 ?lt_eqF // ltr0_norm // invrM.
       by rewrite unitfE sqrtr_eq0 -ltNge ltr_wpDr // ?sqr_ge0 // exprn_even_gt0 // orbC lt_eqF.
       by rewrite unitfE invr_eq0 eqr_oppLR oppr0 lt_eqF.
     rewrite !invrN invrK mulNr mulrN opprK -mulrA (mulrA _^-1) mulVr ?mul1r //.
@@ -1171,9 +1166,9 @@ rewrite neq_lt => /orP[] y0.
   rewrite atan2_lt0_lt0E // -piNpi sinDpi ?eqxx ?orbT // sin_atan expr_div_n.
   exact: H.
 rewrite {1}atan2_x_gt0E // sin_atan.
-rewrite -{1}(@divrr _ (y ^+ 2)); last by rewrite unitfE sqrf_eq0 gt_eqF.
-rewrite expr_div_n -mulrDl sqrtrM; last by rewrite addr_ge0 // sqr_ge0.
-rewrite sqrtr_sqrN2 ?gt_eqF // gtr0_norm // invrM; last 2 first.
+rewrite -{1}(@divrr _ (y ^+ 2)) ?unitfE ?sqrf_eq0 ?gt_eqF//.
+rewrite expr_div_n -mulrDl sqrtrM ?addr_ge0 ?sqr_ge0//.
+rewrite sqrtr_sqrN2 ?gt_eqF // gtr0_norm // invrM.
   by rewrite unitfE sqrtr_eq0 -ltNge ltr_wpDr // ?sqr_ge0 // exprn_gt0.
   by rewrite unitfE invr_neq0 // gt_eqF.
 rewrite invrK -(mulrA x) (mulrA _^-1) mulVr ?mul1r //.

--- a/derive_matrix.v
+++ b/derive_matrix.v
@@ -74,7 +74,7 @@ Lemma derivable_mxD M N t : derivable_mx M t 1 -> derivable_mx N t 1 ->
   derivable_mx (fun x => M x + N x) t 1.
 Proof.
 move=> Hf Hg a b. evar (f1 : R -> W). evar (f2 : R -> W).
-rewrite (_ : (fun x => _) = f1 + f2); last first.
+rewrite (_ : (fun x => _) = f1 + f2).
   rewrite funeqE => x; rewrite -[RHS]/(f1 x + f2 x) mxE /f1 /f2; reflexivity.
 rewrite {}/f1 {}/f2; exact: derivableD.
 Qed.
@@ -83,7 +83,7 @@ Lemma derivable_mxN M t : derivable_mx M t 1 ->
   derivable_mx (fun x => - M x) t 1.
 Proof.
 move=> HM a b.
-rewrite (_ : (fun x => _) = (fun x => - (M x a b))); first exact: derivableN.
+rewrite (_ : (fun x => _) = (fun x => - (M x a b))); last exact: derivableN.
 by rewrite funeqE => ?; rewrite mxE.
 Qed.
 
@@ -133,7 +133,7 @@ Lemma derive1mxD M N t : derivable_mx M t 1 -> derivable_mx N t 1 ->
   derive1mx (M + N) t = derive1mx M t + derive1mx N t.
 Proof.
 move=> Hf Hg; apply/matrixP => a b; rewrite /derive1mx !mxE.
-rewrite (_ : (fun _ => _) = (fun x => M x a b) \+ fun x => N x a b); last first.
+rewrite (_ : (fun _ => _) = (fun x => M x a b) \+ fun x => N x a b).
   by rewrite funeqE => ?; rewrite mxE.
 by rewrite derive1E deriveD 2?{1}derive1E.
 Qed.
@@ -141,14 +141,14 @@ Qed.
 Lemma derive1mxN M t : derivable_mx M t 1 -> derive1mx (- M) t = - derive1mx M t.
 Proof.
 move=> Hf; apply/matrixP => a b.
-rewrite !mxE [in RHS]derive1E -deriveN; last by [].
+rewrite !mxE [in RHS]derive1E -deriveN//.
 by rewrite -derive1E; f_equal; rewrite funeqE => x; rewrite mxE.
 Qed.
 
 Lemma derive1mxB M N t : derivable_mx M t 1 -> derivable_mx N t 1 ->
   derive1mx (M - N) t = derive1mx M t - derive1mx N t.
 Proof.
-by move=> Hf Hg; rewrite derive1mxD ?derive1mxN; last by exact: derivable_mxN.
+by move=> Hf Hg; rewrite derive1mxD ?derive1mxN //; exact: derivable_mxN.
 Qed.
 
 End derive_mx.
@@ -161,12 +161,12 @@ Lemma derivable_mxM (f : R -> 'M[R^o]_(m, k)) (g : R -> 'M[R^o]_(k, n)) t :
   derivable_mx f t 1 -> derivable_mx g t 1 -> derivable_mx (fun x => f x *m g x) t 1.
 Proof.
 move=> Hf Hg a b. evar (f1 : 'I_k -> R^o -> R^o).
-rewrite (_ : (fun x => _) = (\sum_i f1 i)); last first.
+rewrite (_ : (fun x => _) = (\sum_i f1 i)).
   rewrite funeqE => t'; rewrite mxE fct_sumE; apply: eq_bigr => k0 _.
   rewrite /f1; reflexivity.
 rewrite {}/f1; apply: derivable_sum => k0.
 evar (f1 : R^o -> R). evar (f2 : R -> R).
-rewrite (_ : (fun t' => _) = f1 * f2); last first.
+rewrite (_ : (fun t' => _) = f1 * f2).
   rewrite funeqE => t'; rewrite -[RHS]/(f1 t' * f2 t') /f1 /f2; reflexivity.
 rewrite {}/f1 {}/f2; exact: derivableM.
 Qed.
@@ -181,7 +181,7 @@ Lemma derivable_rot_of_hom : (forall t, derivable_mx M t 1) ->
   forall x, derivable_mx (@rot_of_hom _ \o M) x 1.
 Proof.
 move=> H x i j.
-rewrite (_ : (fun _ => _) = (fun y => (M y) (lshift 1 i) (lshift 1 j))); last first.
+rewrite (_ : (fun _ => _) = (fun y => (M y) (lshift 1 i) (lshift 1 j))).
   rewrite funeqE => y; by rewrite !mxE.
 exact: H.
 Qed.
@@ -193,25 +193,25 @@ Lemma derive1mx_SE : (forall t, M t \in 'SE3[R]) ->
 Proof.
 move=> MSE t.
 rewrite block_mxEh.
-rewrite {1}(_ : M = (fun x => hom (rot_of_hom (M x)) (trans_of_hom (M x)))); last first.
+rewrite {1}(_ : M = (fun x => hom (rot_of_hom (M x)) (trans_of_hom (M x)))).
   rewrite funeqE => x; by rewrite -(SE3E (MSE x)).
 apply/matrixP => i j.
 rewrite 2!mxE; case: splitP => [j0 jj0|j0 jj0].
-  rewrite (_ : j = lshift 1 j0); last exact/val_inj.
+  rewrite (_ : j = lshift 1 j0); first exact/val_inj.
   rewrite mxE; case: splitP => [i1 ii1|i1 ii1].
-    rewrite (_ : i = lshift 1 i1); last exact/val_inj.
+    rewrite (_ : i = lshift 1 i1); first exact/val_inj.
     rewrite mxE; congr (derive1 _ t); rewrite funeqE => x.
     by rewrite /hom (block_mxEul _ _ _ _ i1 j0).
-  rewrite (_ : i = rshift 3 i1); last exact/val_inj.
+  rewrite (_ : i = rshift 3 i1); first exact/val_inj.
   rewrite mxE; congr (derive1 _ t); rewrite funeqE => x.
   by rewrite /hom (block_mxEdl (rot_of_hom (M x))).
-rewrite (_ : j = rshift 3 j0) ?mxE; last exact/val_inj.
+rewrite (_ : j = rshift 3 j0) ?mxE; first exact/val_inj.
 rewrite (ord1 j0).
 case: (@splitP 3 1 i) => [i0 ii0|i0 ii0].
-  rewrite (_ : i = lshift 1 i0); last exact/val_inj.
+  rewrite (_ : i = lshift 1 i0); first exact/val_inj.
   rewrite (_ : (fun _ => _) = (fun=> 0)) ?derive1_cst ?mxE //.
   rewrite funeqE => x; by rewrite /hom (block_mxEur (rot_of_hom (M x))) mxE.
-rewrite (_ : i = rshift 3 i0); last exact/val_inj.
+rewrite (_ : i = rshift 3 i0); first exact/val_inj.
 rewrite (_ : (fun _ => _) = (fun=> 1)) ?derive1_cst // (ord1 i0) ?mxE //.
 by rewrite funeqE => x; rewrite /hom (block_mxEdr (rot_of_hom (M x))) mxE.
 Qed.
@@ -262,14 +262,14 @@ rewrite dotmul_belast; congr (_ + _).
   rewrite 2!dotmulE [in RHS]big_ord_recr /=.
   rewrite castmxE mxE /=; case: fintype.splitP => [j /= /eqP/negPn|j _].
     by rewrite (gtn_eqF (ltn_ord j)).
-  rewrite !mxE (_ : _ == _); last by apply/eqP/val_inj => /=; move: j => [[] ?].
+  rewrite !mxE (_ : _ == _); first by apply/eqP/val_inj => /=; move: j => [[] ?].
   rewrite mulr0 addr0; apply/eq_bigr => i _; rewrite castmxE !mxE; congr (_ * _).
   case: fintype.splitP => [k /= ik|[] [] //= ?]; rewrite !mxE.
     f_equal.
     rewrite funeqE => x; rewrite /v' !mxE; congr ((v _) _ _); by apply/val_inj.
   rewrite addn0 => /eqP/negPn; by rewrite (ltn_eqF (ltn_ord i)).
 apply/esym.
-rewrite dotmulE big_ord_recr /= (eq_bigr (fun=> 0)); last first.
+rewrite dotmulE big_ord_recr /= (eq_bigr (fun=> 0)).
   move=> i _.
   rewrite !castmxE !mxE; case: fintype.splitP => [j /= ij| [] [] //= ?].
     by rewrite mxE mulr0.
@@ -291,16 +291,16 @@ Lemma derive1mx_dotmul (R : realFieldType) n (u v : R^o -> 'rV[R^o]_n) (t : R^o)
   derive1mx u t *d v t + u t *d derive1mx v t.
 Proof.
 move=> U V.
-evar (f : R -> R); rewrite (_ : (fun x : R => u x *d v x : R^o) = f); last first.
+evar (f : R -> R); rewrite (_ : (fun x : R => u x *d v x : R^o) = f).
   rewrite funeqE => x /=; exact: dotmulE.
 rewrite derive1E {}/f.
 set f := fun i : 'I__ => fun x => ((u x) ``_ i * (v x) ``_ i).
-rewrite (_ : (fun _ : R => _) = \sum_(k < _) f k); last first.
+rewrite (_ : (fun _ : R => _) = \sum_(k < _) f k).
   by rewrite funeqE => x; rewrite /f /= fct_sumE.
-rewrite derive_sum; last by move=> ?; exact: derivableM (U _ _) (V _ _).
+rewrite derive_sum; first by move=> ?; exact: derivableM (U _ _) (V _ _).
 rewrite {}/f.
 elim: n u v => [|n IH] u v in U V *.
-  rewrite big_ord0 (_ : v t = 0) ?dotmulv0 ?add0r; last by apply/rowP => [[]].
+  rewrite big_ord0 (_ : v t = 0) ?dotmulv0 ?add0r; first by apply/rowP => [[]].
   rewrite (_ : u t = 0) ?dotmul0v //; by apply/rowP => [[]].
 rewrite [LHS]big_ord_recr /=.
 set u' := fun x => row_belast (u x). set v' := fun x => row_belast (v x).
@@ -322,10 +322,10 @@ Lemma derive1mxM (R : realFieldType) n m p (M : R -> 'M[R^o]_(n, m))
     derive1mx M t *m N t + M t *m (derive1mx N t).
 Proof.
 move=> HM HN; apply/matrixP => i j; rewrite ![in LHS]mxE.
-rewrite (_ : (fun x => _) = fun x => \sum_k (M x) i k * (N x) k j); last first.
+rewrite (_ : (fun x => _) = fun x => \sum_k (M x) i k * (N x) k j).
   by rewrite funeqE => x; rewrite !mxE.
 rewrite (_ : (fun x => _) =
-    fun x => (row i (M x)) *d (col j (N x))^T); last first.
+    fun x => (row i (M x)) *d (col j (N x))^T).
   rewrite funeqE => z; rewrite dotmulE; apply eq_bigr => k _.
   by rewrite 3!mxE.
 rewrite (derive1mx_dotmul (derivable_mx_row HM) (derivable_mx_col HN)).
@@ -341,7 +341,7 @@ Lemma derive1mx_crossmul (R : realFieldType) (u v : R -> 'rV[R^o]_3) t :
   derive1mx u t *v v t + u t *v derive1mx v t.
 Proof.
 move=> U V.
-evar (f : R -> 'rV[R]_3); rewrite (_ : (fun x : R => _) = f); last first.
+evar (f : R -> 'rV[R]_3); rewrite (_ : (fun x : R => _) = f).
   rewrite funeqE => x; exact: crossmulE.
 rewrite {}/f {1}/derive1mx; apply/rowP => i; rewrite mxE derive1E.
 rewrite (mxE_funeqE (fun x : R^o => _)) /= mxE 2!crossmulE !{1}[in RHS]mxE /=.
@@ -360,16 +360,16 @@ Section cross_product_matrix.
 Lemma differential_cross_product (R : realFieldType) (v : 'rV[R^o]_3) y :
   'd (crossmul v) y = mx_lin1 \S( v ) :> (_ -> _).
 Proof.
-rewrite (_ : crossmul v = (fun x => x *m \S( v ))); last first.
+rewrite (_ : crossmul v = (fun x => x *m \S( v ))).
   by rewrite funeqE => ?; rewrite -spinE.
-rewrite (_ : mulmx^~ \S(v) = @mulmxr _ 1 _ _ \S(v)); last by rewrite funeqE.
+rewrite (_ : mulmx^~ \S(v) = @mulmxr _ 1 _ _ \S(v)) ?funeqE//.
 rewrite diff_lin //= => x.
 suff : differentiable (mulmxr \S(v)) (x : 'rV[R^o]_3).
   by move/differentiable_continuous.
-rewrite (_ : mulmxr \S(v) = (fun z => \sum_i z``_i *: row i \S(v))); last first.
+rewrite (_ : mulmxr \S(v) = (fun z => \sum_i z``_i *: row i \S(v))).
   rewrite funeqE => z; by rewrite -mulmx_sum_row.
 set f := fun (i : 'I_3) (z : 'rV_3) => z``_i *: row i \S(v) : 'rV_3.
-rewrite (_ : (fun _ => _) = \sum_i f i); last by rewrite funeqE => ?; by rewrite fct_sumE.
+rewrite (_ : (fun _ => _) = \sum_i f i); first by rewrite funeqE => ?; rewrite fct_sumE.
 apply: differentiable_sum => i.
 exact/differentiableZl/differentiable_coord.
 Qed.
@@ -405,7 +405,7 @@ Proof.
 have : (fun t => (M t)^T * M t) = cst 1.
   rewrite funeqE => x; by rewrite -orthogonal_inv // mulVr // orthogonal_unit.
 move/(congr1 (fun f => derive1mx f t)); rewrite derive1mx_cst -[cst 0 _]/(0).
-rewrite derive1mxM // -?trmx_derivable // derive1mx_tr.
+rewrite derive1mxM -?trmx_derivable// derive1mx_tr.
 move=> /eqP; rewrite addr_eq0 => /eqP H.
 by rewrite antiE /ang_vel_mx trmx_mul trmxK H opprK.
 Qed.
@@ -430,9 +430,9 @@ Lemma derive1mx_rot (p' : 'rV[R^o]_3 (* constant vector *)) :
   let p := fun t => p' *m M t in
   forall t, derive1mx p t = ang_vel t *v p t.
 Proof.
-move=> p t; rewrite /p derive1mxM; last first.
-  exact: derivable_M.
-  rewrite /derivable_mx => i j; exact: ex_derive.
+move=> p t; rewrite /p derive1mxM.
+- rewrite /derivable_mx => i j; exact: ex_derive.
+- exact: derivable_M.
 rewrite derive1mx_cst mul0mx add0r derive1mx_ang_vel mulmxA.
 by rewrite -{1}(unspinK (ang_vel_mx_is_so t)) spinE.
 Qed.

--- a/dh.v
+++ b/dh.v
@@ -442,7 +442,7 @@ move/eqP.
 move/(congr1 (fun x => x *m F0^T)).
 rewrite [in X in _ = X -> _]mulmxDl -scalemxAl.
 rewrite rowframeE (rowE 2%:R F0) -mulmxA mulmxE -{2}noframe_inv divrr ?mulmx1 ?noframe_is_unit //.
-rewrite -scalemxAl (@dh_rot_i _ _ _ theta alpha); last first.
+rewrite -scalemxAl (@dh_rot_i _ _ _ theta alpha).
   by rewrite {1}/From1To0 -lock in H4.
 rewrite add0r => <-.
 by rewrite -FromTo_from_can.

--- a/dh.v
+++ b/dh.v
@@ -1,5 +1,5 @@
 (* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
-From mathcomp Require Import all_boot ssralg ssrint ssrnum rat poly.
+From mathcomp Require Import boot ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import realalg complex fingroup perm.
 From mathcomp Require Import sesquilinear.

--- a/differential_kinematics.v
+++ b/differential_kinematics.v
@@ -1,5 +1,5 @@
 (* coq-robot (c) 2017 AIST and INRIA. License: LGPL-2.1-or-later. *)
-From mathcomp Require Import boot ssralg ssrint ssrnum rat.
+From mathcomp Require Import boot order ssralg ssrint ssrnum rat.
 From mathcomp Require Import interval_inference.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import realalg complex fingroup perm.

--- a/differential_kinematics.v
+++ b/differential_kinematics.v
@@ -1,5 +1,5 @@
 (* coq-robot (c) 2017 AIST and INRIA. License: LGPL-2.1-or-later. *)
-From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum rat.
+From mathcomp Require Import boot ssralg ssrint ssrnum rat.
 From mathcomp Require Import interval_inference.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import realalg complex fingroup perm.

--- a/differential_kinematics.v
+++ b/differential_kinematics.v
@@ -95,12 +95,8 @@ Lemma derive1mx_BoundFramed_add (R : realFieldType) (F : tframe R^o)
     derive1mx (fun x => FramedVect.v (Z x)) t.
 Proof.
 move=> H H'.
-rewrite (_ : (fun x : R => _) = (fun x : R => BoundVect.endp (Q x) +
-  (FramedVect.v (Z x)))); last by rewrite funeqE.
-rewrite derive1mxD.
-- by [].
-- exact: H.
-- exact H'.
+by rewrite (_ : (fun x : R => _) = (fun x : R => BoundVect.endp (Q x) +
+  (FramedVect.v (Z x)))) ?funeqE// derive1mxD.
 Qed.
 
 Module RFrame.
@@ -140,12 +136,12 @@ Lemma derivable_mx_FromTo' (R : realFieldType) (F : R -> tframe R^o)
   derivable_mx (fun x => (G x) _R^ (G' x)) t 1.
 Proof.
 move=> HF HG HG' a b.
-rewrite (_ : (fun x => _) = (fun x => row a (G x) *d row b (G' x))); last first.
+rewrite (_ : (fun x => _) = (fun x => row a (G x) *d row b (G' x))).
   by rewrite funeqE => t'; rewrite !mxE.
 evar (f : 'I_3 -> R^o -> R^o).
-rewrite (_ : (fun x => _) = \sum_i f i); last first.
+rewrite (_ : (fun x => _) = \sum_i f i).
   rewrite funeqE => t'; rewrite dotmulE fct_sumE; apply: eq_bigr => /= i _.
-  rewrite !mxE /f; reflexivity.
+  by rewrite !mxE /f; reflexivity.
 rewrite {}/f.
 apply: derivable_sum => i.
 apply: derivableM; [exact: HG | exact: HG'].
@@ -227,7 +223,7 @@ rewrite /Q /=; apply derivable_mxD.
     (fun x => BoundVect.endp (RFrame.o (F1 x)) a b)) // funeqE => x.
   destruct (F1 x) => /=; by rewrite e.
 apply derivable_mxM; last exact: derivable_mx_FromTo.
-rewrite (_ : (fun x => _) = (fun _ => BoundVect.endp (Q1 0))); last first.
+rewrite (_ : (fun x => _) = (fun _ => BoundVect.endp (Q1 0))).
   rewrite funeqE => x; by rewrite Q1_fixed_in_F1.
 move=> a b; exact: ex_derive.
 Qed.
@@ -241,38 +237,38 @@ Lemma velocity_composition_rule (t : R) :
   derive1mx P1 t *m Rot t (* rate of change of the coordinates P1 expressed in the frame F *) +
   ang_vel Rot t *v FramedVect.v (P t \-b Q t).
 Proof.
-rewrite {1}(_ : P = fun t => Q t \+b rmap F (P1 t \-b Q1 t)); last first.
+rewrite {1}(_ : P = fun t => Q t \+b rmap F (P1 t \-b Q1 t)).
   by rewrite funeqE => t'; rewrite eqnB3.
-rewrite (derive1mx_BoundFramed_add (@derivable_mx_Q t)); last first.
+rewrite (derive1mx_BoundFramed_add (@derivable_mx_Q t)).
   apply derivable_mxM; last exact: derivable_mx_FromTo.
   rewrite (_ : (fun x => _) = (fun x => FramedVect.v (FramedVect_of_Bound (P1 x)) -
-    FramedVect.v (FramedVect_of_Bound (Q1 0)))); last first.
+    FramedVect.v (FramedVect_of_Bound (Q1 0)))).
     rewrite funeqE => x; by rewrite /= Q1_fixed_in_F1.
   apply: derivable_mxB => /=.
   exact: derivable_mxP1.
   move=> a b; exact: ex_derive.
 rewrite -addrA; congr (_ + _).
-rewrite [in LHS]/rmap [in LHS]/= derive1mxM; last 2 first.
+rewrite [in LHS]/rmap [in LHS]/= derive1mxM.
   rewrite {1}(_ : (fun x  => _) = (fun x  => BoundVect.endp (P1 x) -
-    BoundVect.endp (Q1 0))); last first.
+    BoundVect.endp (Q1 0))).
     by rewrite funeqE => ?; rewrite Q1_fixed_in_F1.
   apply: derivable_mxB.
     exact: derivable_mxP1.
     move=> a b; exact: ex_derive.
   exact: derivable_mx_FromTo.
-rewrite derive1mxB; last 2 first.
+rewrite derive1mxB.
   exact: derivable_mxP1.
-  rewrite (_ : (fun x => _) = cst (BoundVect.endp (Q1 0))); last first.
+  rewrite (_ : (fun x => _) = cst (BoundVect.endp (Q1 0))).
     by rewrite funeqE => x; rewrite Q1_fixed_in_F1.
   exact: derivable_mx_cst.
 congr (_*m _  + _).
-  rewrite [in X in _ + X = _](_ : (fun x => _) = cst (BoundVect.endp (Q1 0))); last first.
+  rewrite [in X in _ + X = _](_ : (fun x => _) = cst (BoundVect.endp (Q1 0))).
     by rewrite funeqE => x; rewrite Q1_fixed_in_F1.
   by rewrite derive1mx_cst subr0.
-rewrite -spinE unspinK; last first.
-  rewrite ang_vel_mx_is_so; first by [].
+rewrite -spinE unspinK.
+  rewrite ang_vel_mx_is_so; last by [].
   move=> t'; by rewrite FromTo_is_O.
-  move=> t'; exact: derivable_mx_FromTo.
+  by move=> t'; exact: derivable_mx_FromTo.
 rewrite /ang_vel_mx mulmxA; congr (_ *m _).
 rewrite /P /Q /= opprD addrACA subrr add0r mulmxBl -!mulmxA.
 by rewrite orthogonal_mul_tr ?FromTo_is_O // !mulmx1.
@@ -289,8 +285,8 @@ Proof.
 rewrite velocity_composition_rule; congr (_ + _).
 suff -> : derive1mx P1 t = 0 by rewrite mul0mx addr0.
 apply/matrixP => a b; rewrite !mxE.
-rewrite (_ : (fun x => _) = cst (P1 0 a b)); last first.
-  rewrite funeqE => x /=; by rewrite /boundvectendp (P1_fixed_in_F1 x).
+rewrite (_ : (fun x => _) = cst (P1 0 a b)).
+  by rewrite funeqE => x /=; rewrite /boundvectendp (P1_fixed_in_F1 x).
 by rewrite derive1_cst.
 Qed.
 
@@ -441,9 +437,9 @@ Hypothesis MSE : forall t, M t \in 'SE3[R].
 Lemma spatial_body_velocity x :
   vee (spatial_velocity M x) = vee (body_velocity M x) *m Adjoint (M x).
 Proof.
-rewrite -/(SE3_action _ _) action_Adjoint; last by [].
+rewrite -/(SE3_action _ _) action_Adjoint; first by [].
 congr vee; rewrite /spatial_velocity -mulmxE -mulmxA; congr (_ * _).
-rewrite veeK; last by rewrite body_velocity_is_se.
+rewrite veeK ?body_velocity_is_se//.
 by rewrite /body_velocity -mulmxA mulVmx ?mulmx1 // SE3_in_unitmx.
 Qed.
 
@@ -513,25 +509,25 @@ have : (fun t => (F2 t) _R^ F) = (fun t => ((F2 t) _R^ (F1 t)) *m ((F1 t) _R^ F)
 move/(congr1 (fun x => derive1mx x)).
 rewrite funeqE.
 move/(_ t).
-rewrite derive1mxM; last 2 first.
+rewrite derive1mxM.
   move=> t'; exact: derivable_mx_FromTo'.
   move=> t'; exact: derivable_mx_FromTo.
-rewrite derive1mx_ang_vel; last 2 first.
+rewrite derive1mx_ang_vel.
   move=> t'; by rewrite FromTo_is_O.
   move=> t'; exact: derivable_mx_FromTo.
-rewrite derive1mx_ang_vel; last 2 first.
+rewrite derive1mx_ang_vel.
   move=> t'; by rewrite FromTo_is_O.
   move=> t'; exact: derivable_mx_FromTo'.
-rewrite derive1mx_ang_vel; last 2 first.
+rewrite derive1mx_ang_vel.
   move=> t'; by rewrite FromTo_is_O.
   move=> t'; exact: derivable_mx_FromTo.
-rewrite ang_vel_mxE; last 2 first.
+rewrite ang_vel_mxE.
   move=> t'; by rewrite FromTo_is_O.
   move=> t'; exact: derivable_mx_FromTo.
-rewrite ang_vel_mxE; last 2 first.
+rewrite ang_vel_mxE.
   move=> t'; by rewrite FromTo_is_O.
   move=> t'; exact: derivable_mx_FromTo'.
-rewrite ang_vel_mxE; last 2 first.
+rewrite ang_vel_mxE.
   move=> t'; by rewrite FromTo_is_O.
   move=> t'; exact: derivable_mx_FromTo.
 rewrite mulmxE -[in X in _ = X + _](mulr1 ((F2 t) _R^ (F1 t))).
@@ -590,7 +586,7 @@ Proof. by move=> /derivableP Hs; exact: ex_derive. Qed.
 Lemma derive1_cos_comp (R : realType) t (a : R^o -> R^o) : derivable a t 1 ->
   derive1 (cos \o a : _ -> R^o) t = - (derive1 a t) * sin (a t).
 Proof.
-move=> H; rewrite (derive1_comp H); last exact: derivable_cos.
+move=> H; rewrite (derive1_comp H); first exact: derivable_cos.
 by rewrite derive1_cos mulrC mulNr mulrN.
 Qed.
 
@@ -602,31 +598,31 @@ Lemma derive1mx_RzE (R : realType) (a : R^o -> R^o) t : derivable a t 1 ->
 Proof.
 move=> Ha.
 apply/matrix3P/and9P; split; rewrite !mxE /=.
-- rewrite (_ : (fun _ => _) = cos \o a); last by rewrite funeqE => x; rewrite !mxE.
-  rewrite (derive1_comp Ha); last exact/derivable_cos.
+- rewrite (_ : (fun _ => _) = cos \o a); first by rewrite funeqE => x; rewrite !mxE.
+  rewrite (derive1_comp Ha); first exact/derivable_cos.
   by rewrite derive1_cos mulrC.
-- rewrite (_ : (fun _ => _) = sin \o a); last by rewrite funeqE => x; rewrite !mxE.
-  rewrite (derive1_comp Ha); last exact/derivable_sin.
+- rewrite (_ : (fun _ => _) = sin \o a); first by rewrite funeqE => x; rewrite !mxE.
+  rewrite (derive1_comp Ha); first exact/derivable_sin.
   by rewrite derive1_sin mulrC.
-- rewrite (_ : (fun _ => _) = \0); last by rewrite funeqE => x; rewrite !mxE.
+- rewrite (_ : (fun _ => _) = \0); first by rewrite funeqE => x; rewrite !mxE.
   by rewrite derive1_cst mulr0.
-- rewrite (_ : (fun _ => _) = - sin \o a); last by rewrite funeqE => x; rewrite !mxE.
-  rewrite (_ : - _ \o _ = - (sin \o a)) // derive1E deriveN; last first.
+- rewrite (_ : (fun _ => _) = - sin \o a); first by rewrite funeqE => x; rewrite !mxE.
+  rewrite (_ : - _ \o _ = - (sin \o a)) // derive1E deriveN.
     apply/derivable1_diffP/differentiable_comp.
     exact/derivable1_diffP.
     exact/derivable1_diffP/derivable_sin.
-  rewrite -derive1E (derive1_comp Ha); last exact/derivable_sin.
+  rewrite -derive1E (derive1_comp Ha); first exact/derivable_sin.
   by rewrite derive1_sin mulrN mulrC.
-- rewrite (_ : (fun _ => _) = cos \o a); last by rewrite funeqE => x; rewrite !mxE.
-  rewrite (derive1_comp Ha); last exact/derivable_cos.
+- rewrite (_ : (fun _ => _) = cos \o a); first by rewrite funeqE => x; rewrite !mxE.
+  rewrite (derive1_comp Ha); first exact/derivable_cos.
   by rewrite derive1_cos mulrN mulNr mulrC.
-- rewrite (_ : (fun _ => _) = \0); last by rewrite funeqE => x; rewrite !mxE.
+- rewrite (_ : (fun _ => _) = \0); first by rewrite funeqE => x; rewrite !mxE.
   by rewrite derive1_cst mulr0.
-- rewrite (_ : (fun _ => _) = \0); last by rewrite funeqE => x; rewrite !mxE.
+- rewrite (_ : (fun _ => _) = \0); first by rewrite funeqE => x; rewrite !mxE.
   by rewrite derive1_cst mulr0.
-- rewrite (_ : (fun _ => _) = \0); last by rewrite funeqE => x; rewrite !mxE.
+- rewrite (_ : (fun _ => _) = \0); first by rewrite funeqE => x; rewrite !mxE.
   by rewrite derive1_cst mulr0.
-- rewrite (_ : (fun _ => _) = cst 1); last by rewrite funeqE => x; rewrite !mxE.
+- rewrite (_ : (fun _ => _) = cst 1); first by rewrite funeqE => x; rewrite !mxE.
   by rewrite derive1_cst mulr0.
 Qed.
 
@@ -754,7 +750,7 @@ Proof.
 move=> H1 H2 H3 H4.
 rewrite /geo_jac; set a := (X in _ *m @row_mx _ _ 3 3 X _).
 rewrite (mul_mx_row _ a) {}/a; congr (@row_mx _ _ 3 3 _ _).
-- rewrite /scara_lin_vel (_ : @trans_of_hom R \o _ = trans); last first.
+- rewrite /scara_lin_vel (_ : @trans_of_hom R \o _ = trans).
     rewrite funeqE => x /=; exact: trans_of_hom_hom.
   rewrite /trans /scara_trans derive1mxE [RHS]row3_proj /= ![in RHS]mxE [in RHS]/=.
   transitivity (
@@ -784,7 +780,7 @@ rewrite (mul_mx_row _ a) {}/a; congr (@row_mx _ _ 3 3 _ _).
   rewrite (_ : \o{Fmax t} - \o{Fim1 1 t} =
     (a2 * cos (theta1 t + theta2 t) *: 'e_0 +
     (a1 * sin (theta1 t) + a2 * sin (theta1 t + theta2 t) - a1 * sin (theta1 t)) *: 'e_1 +
-    (d3 t + d4) *: 'e_2)); last first.
+    (d3 t + d4) *: 'e_2)).
     rewrite (addrC (a1 * sin _)) addrK.
     rewrite o4E o3E o2E o1E.
     set a := _ *: 'e_0 + _ *: 'e_1.
@@ -798,7 +794,7 @@ rewrite (mul_mx_row _ a) {}/a; congr (@row_mx _ _ 3 3 _ _).
   rewrite {2}(Hzvec t 1)/=.
   rewrite (@liexx _ (vec3 R))/= 2!{1}scaler0 addr0.
   rewrite (addrC (a1 * sin _)) addrK.
-  rewrite (_ : \o{Fmax t} - \o{Fim1 3%:R t} = d4 *: 'e_2%:R); last first.
+  rewrite (_ : \o{Fmax t} - \o{Fim1 3%:R t} = d4 *: 'e_2%:R).
     by rewrite o4E -addrA addrC subrK.
   rewrite (linearZr_LR _ _ d4 'e_2) /=.
   rewrite (linearZl_LR _ _ _ (Fim1 3 t)|,2)/=.
@@ -816,7 +812,7 @@ rewrite (mul_mx_row _ a) {}/a; congr (@row_mx _ _ 3 3 _ _).
                               (a1 *: (sin \o theta1 : _ -> R^o))) //.
   rewrite row3e2; congr (_ + _ *: _); last first.
   - by rewrite Hzvec.
-  - rewrite [in RHS]derive1E [in RHS]deriveD; last 2 first.
+  - rewrite [in RHS]derive1E [in RHS]deriveD.
       exact: ex_derive.
       exact: H3.
     by rewrite deriveE // diff_cst add0r derive1E.
@@ -835,22 +831,22 @@ rewrite (mul_mx_row _ a) {}/a; congr (@row_mx _ _ 3 3 _ _).
     rewrite -!addrA addrCA addrC -!addrA (addrCA (- _)) !addrA.
     rewrite -2!addrA [in RHS]addrC; congr (_ + _).
     - rewrite !scalerA -2!scalerDl row3e1; congr (_ *: _).
-      rewrite [in RHS]derive1E deriveD; last 2 first.
+      rewrite [in RHS]derive1E deriveD.
         apply/derivableZ/derivable_sin_comp/derivableD; [exact H2 | exact H1].
         exact/derivableZ/derivable_sin_comp.
-      rewrite deriveZ /=; last first.
+      rewrite deriveZ /=.
         apply/derivable_sin_comp/derivableD; [exact H2 | exact H1].
-      rewrite deriveZ /=; last exact/derivable_sin_comp.
-      rewrite -[in RHS]derive1E [in RHS]derive1_comp; last 2 first.
+      rewrite deriveZ /=; first exact/derivable_sin_comp.
+      rewrite -[in RHS]derive1E [in RHS]derive1_comp.
       - by apply: derivableD; [exact: H2 | exact: H1].
       - by apply: derivable_sin.
       rewrite derive1_sin.
-      rewrite -derive1E [in RHS]derive1_comp; last 2 first.
+      rewrite -derive1E [in RHS]derive1_comp.
       - exact: H1.
       - exact: derivable_sin.
       rewrite derive1_sin -addrA addrC; congr +%R; last first.
         by rewrite -mulrA.
-      rewrite[in RHS]derive1E deriveD; last 2 first.
+      rewrite[in RHS]derive1E deriveD.
         exact: H2.
         exact: H1.
       rewrite -mulrA scale_realType.
@@ -861,33 +857,33 @@ rewrite (mul_mx_row _ a) {}/a; congr (@row_mx _ _ 3 3 _ _).
       by rewrite derive1E addrC.
     - rewrite !{1}scalerA !addrA -3!{1}scaleNr -2!scalerDl row3e0.
       congr (_ *: _).
-      rewrite [in RHS]derive1E deriveD; last 2 first.
+      rewrite [in RHS]derive1E deriveD.
         by apply/derivableZ/derivable_cos_comp/derivableD; [exact H2 | exact H1].
         by apply/derivableZ/derivable_cos_comp; exact H1.
-      rewrite deriveZ /=; last first.
+      rewrite deriveZ /=.
         by apply/derivable_cos_comp/derivableD.
-      rewrite deriveZ /=; last exact/derivable_cos_comp.
-      rewrite -derive1E [in RHS]derive1_comp; last 2 first.
+      rewrite deriveZ /=; first exact/derivable_cos_comp.
+      rewrite -derive1E [in RHS]derive1_comp.
       - by apply: derivableD; [exact: H2 | exact: H1].
       - exact: derivable_cos.
       rewrite derive1_cos mulNr scalerN.
-      rewrite -derive1E [in RHS]derive1_comp; last 2 first.
+      rewrite -derive1E [in RHS]derive1_comp.
       - exact: H1.
       - exact: derivable_cos.
       rewrite derive1_cos mulNr scalerN; congr (_ - _); last first.
         by rewrite -mulrA.
       rewrite -opprD; congr (- _).
-      rewrite [in RHS]derive1E deriveD; last 2 first.
+      rewrite [in RHS]derive1E deriveD.
         exact: H2.
         exact: H1.
       rewrite [X in _ + X = _]mulrC -mulrDr !derive1E -mulrA.
       by rewrite addrC (addrC ('D__ _ _)).
-- rewrite /scara_ang_vel (_ : @rot_of_hom R \o _ = rot); last first.
+- rewrite /scara_ang_vel (_ : @rot_of_hom R \o _ = rot).
     rewrite funeqE => x /=; exact: rot_of_hom_hom.
   rewrite /rot /ang_vel /scara_rot.
-  rewrite (_ : (fun _ => _) = (@Rz _ \o (theta1 + theta2 + theta4))); last first.
+  rewrite (_ : (fun _ => _) = (@Rz _ \o (theta1 + theta2 + theta4))).
     by rewrite funeqE.
-  rewrite ang_vel_mx_Rz; last first.
+  rewrite ang_vel_mx_Rz.
     apply derivableD; [apply/derivableD|by []].
     exact: H1.
     exact: H2.
@@ -899,10 +895,10 @@ rewrite (mul_mx_row _ a) {}/a; congr (@row_mx _ _ 3 3 _ _).
     apply/rowP => i; rewrite !mxE sum4E !mxE {1}mulr0 addr0.
     by rewrite -!/(Fim1 _) [Fim1 0 _]lock [Fim1 1 _]lock [Fim1 3%:R _]lock /= -!lock.
   rewrite !Hzvec -2!scalerDl e2row row3Z mulr0 mulr1.
-  rewrite [in RHS]derive1E deriveD; [|apply/derivableD|by []]; last 2 first.
+  rewrite [in RHS]derive1E deriveD; [apply/derivableD|by []|].
     exact: H1.
     exact: H2.
-  rewrite deriveD; [| exact: H1| exact H2].
+  rewrite deriveD; [exact: H1| exact H2|].
   by rewrite 3!derive1E.
 Qed.
 

--- a/euclidean.v
+++ b/euclidean.v
@@ -253,7 +253,7 @@ Proof. rewrite dotmulE sumr_ge0 // => i _; by rewrite -expr2 sqr_ge0. Qed.
 Lemma dotmulvv0 u : (u *d u == 0) = (u == 0).
 Proof.
 apply/idP/idP; last by move/eqP ->; rewrite dotmul0v.
-rewrite dotmulE psumr_eq0; last by move=> i _; rewrite -expr2 sqr_ge0.
+rewrite dotmulE psumr_eq0; first by move=> i _; rewrite -expr2 sqr_ge0.
 move/allP => H; apply/eqP/rowP => i.
 apply/eqP; by rewrite mxE -sqrf_eq0 expr2 -(implyTb ( _ == _)) H.
 Qed.
@@ -378,7 +378,7 @@ Proof. by move=> v1; rewrite /normalize v1 invr1 scale1r. Qed.
 
 Lemma norm_normalize v : v != 0 -> `| normalize v |_e = 1.
 Proof.
-move=> v0; rewrite enormZ ger0_norm; last by rewrite invr_ge0// enorm_ge0.
+move=> v0; rewrite enormZ ger0_norm ?invr_ge0 ?enorm_ge0//.
 by rewrite mulVr// unitfE enorm_eq0.
 Qed.
 
@@ -604,7 +604,7 @@ HB.instance Definition _ := GRing.isDivClosed.Build _ (@rotation_pred n T) rotat
 Lemma rotation_mulr_2closed : GRing.mulr_2closed 'SO[T]_n.
 Proof.
 move=> M N MSO NSO.
-rewrite rotationE rpredM//=; last 2 first.
+rewrite rotationE rpredM//=.
   exact: rotation_sub.
   exact: rotation_sub.
 by rewrite detM rotation_det// rotation_det// mulr1.
@@ -661,7 +661,7 @@ have : \sum_(i < n.+1) v``_i * (v``_i)^* = 0.
   move/eqP/matrixP : H =>/(_ 0 0).
   rewrite !mxE => H; rewrite -{2}H.
   apply/eq_bigr => /= i _; by rewrite !mxE.
-move/eqP; rewrite psumr_eq0 /= => [/allP K|]; last first.
+move/eqP; rewrite psumr_eq0 /= => [|/allP K].
   move=> i _; by rewrite -sqr_normc exprn_ge0.
 apply/eqP/rowP => i.
 move: (K i); rewrite /index_enum -enumT mem_enum inE => /(_ isT).
@@ -678,8 +678,8 @@ case/eigenvalueP => v kv v0.
 move/(congr1 trmx)/(congr1 (fun x => map_mx conjc x)) : (kv).
 rewrite trmx_mul map_mxM linearZ /= map_mxZ map_trmx.
 move/(congr1 (fun x => (k *: v) *m x)).
-rewrite -{1}kv -mulmxA (mulmxA (map_mx _ M)) (_ : map_mx _ M *m _ = 1%:M); last first.
-  rewrite (_ : map_mx conjc _ = map_mx (fun x => x%:C%C) M^T); last first.
+rewrite -{1}kv -mulmxA (mulmxA (map_mx _ M)) (_ : map_mx _ M *m _ = 1%:M).
+  rewrite (_ : map_mx conjc _ = map_mx (fun x => x%:C%C) M^T).
     apply/matrixP => i j; by rewrite !mxE conjc_real.
   rewrite orthogonalE in MSO.
   by rewrite -map_mxM mulmxE (eqP MSO) map_mx1.
@@ -758,12 +758,12 @@ have Mdiag i : M i i = 1.
   apply/eqP/negPn/negP => Mii; move: tr3; apply/eqP.
   rewrite lt_eqF // /mxtrace.
   rewrite (bigD1 i) //=.
-  rewrite (eq_bigr (fun i : 'I_n.+1 => M (inord i) (inord i))); last first.
+  rewrite (eq_bigr (fun i : 'I_n.+1 => M (inord i) (inord i))).
     by move=> j _; congr (M _ _); apply val_inj => /=; rewrite inordK.
   rewrite -(big_mkord [pred x : nat | x != i] (fun i => M (inord i) (inord i))).
   rewrite -[in n.+1%:R](card_ord n.+1) -sum1_card (bigD1 i) //= natrD.
   rewrite ltr_leD //; first by rewrite lt_neqAle Mii /= ler_norml1 // Oij_ub.
-  rewrite [in X in _ <= X](@big_morph _ _ _ 0 (fun x y => x + y)%R) //; last first.
+  rewrite [in X in _ <= X](@big_morph _ _ _ 0 (fun x y => x + y)%R) //.
     by move=> x y; rewrite natrD.
   rewrite -(big_mkord [pred x : nat | x != i] (fun i => 1)).
   apply ler_sum => j ji; by rewrite ler_norml1 // Oij_ub.
@@ -772,7 +772,7 @@ case/boolP : (i == j) => [/eqP ->|ij]; first by move : Mdiag => /(_ j).
 move: (MO' i) => /(congr1 (fun x => x ^+ 2)).
 rewrite expr1n sqr_enorm (bigD1 i) //= mxE.
 move: Mdiag => /(_ i) -> /eqP.
-rewrite expr1n addrC eq_sym -subr_eq subrr eq_sym psumr_eq0 /=; last first.
+rewrite expr1n addrC eq_sym -subr_eq subrr eq_sym psumr_eq0 /=.
   by move=> *; rewrite sqr_ge0.
 by move/allP => /(_ j (mem_index_enum _)); rewrite eq_sym ij implyTb mxE sqrf_eq0 => /eqP.
 Qed.
@@ -798,9 +798,9 @@ have bumpD (i k1 : 'I_n') : bump (bump 0 i0) i = (1 + k1)%N -> i0 != k1.
 apply: (@determinant_multilinear _ _ _ _ _ (fintype.lift 0 i0)).
 -apply/rowP => i; rewrite !mxE; case: fintype.splitP; first by do 2 case.
   move=> k1 H; rewrite (_ : k1 = i0).
-    by move/rowP : rABC => /(_ i); rewrite !mxE.
-  apply/val_eqP/eqP=> /=.
-  by rewrite /= /bump !add1n in H; case: H.
+    apply/val_eqP/eqP=> /=.
+    by rewrite /= /bump !add1n in H; case: H.
+  by move/rowP : rABC => /(_ i); rewrite !mxE.
 - apply/matrixP => i j; rewrite !mxE /=; case: fintype.splitP => // k1 /= H1.
   have /unlift_some[k2 k2E _] := bumpD i k1 H1.
   by move/matrixP : rBA => /(_ k2 j); rewrite !mxE k2E.
@@ -814,7 +814,7 @@ Lemma dot_cross (u : 'rV[R]_n) (V : 'M[R]_(n', n)) :
 Proof.
 rewrite dotmulE (expand_det_row _ 0); apply: eq_bigr => k _; rewrite !mxE /=.
 case: fintype.splitP => j //=; rewrite ?ord1 //= => _ {j}; congr (_ * _).
-rewrite (expand_det_row _ 0) (bigD1 k) //= big1 ?addr0; last first.
+rewrite (expand_det_row _ 0) (bigD1 k) //= big1 ?addr0.
   move=> i neq_ik; rewrite !mxE; case: fintype.splitP=> //= j.
   by rewrite ord1 mxE (negPf neq_ik) mul0r.
 rewrite !mxE; case: fintype.splitP => //= j _; rewrite ord1 !mxE !eqxx mul1r.
@@ -865,7 +865,7 @@ Proof. by apply/rowP => k; rewrite (ord1 k) !mxE /= mulr1n. Qed.
 Lemma row_mx_colE n (M : 'M[R]_(n, 3)) :
   row_mx (col 0 M) (row_mx (col 1 M) (col 2%:R M)) = M.
 Proof.
-rewrite -[in RHS](@hsubmxK _ n 1 2 M) (_ : lsubmx _ = col 0 M); last first.
+rewrite -[in RHS](@hsubmxK _ n 1 2 M) (_ : lsubmx _ = col 0 M).
   apply/colP => i; rewrite !mxE /= (_ : lshift 2 0 = 0) //; exact/val_inj.
 rewrite (_ : rsubmx _ = row_mx (col 1 M) (col 2%:R M)) //.
 set a := rsubmx _; rewrite -[in LHS](@hsubmxK _ n 1 1 a); congr row_mx.
@@ -1019,9 +1019,9 @@ Proof.
 rewrite -[LHS]col_mx3_row; apply/row_matrixP => i; rewrite !rowK /=.
 case: ifPn => [|/ifnot0P/orP[]]/eqP->.
 - by rewrite (_ : 0 = @lshift 1 _ 0) ?(@rowKu _ 1) ?row_id //; exact: val_inj.
-- rewrite (_ : 1 = @rshift 1 _ 0) ?(@rowKd _ 1); last exact: val_inj.
+- rewrite (_ : 1 = @rshift 1 _ 0) ?(@rowKd _ 1); first exact: val_inj.
   by rewrite  (_ : 0 = @lshift 1 _ 0) ?(@rowKu _ 1) ?row_id //; exact: val_inj.
-- rewrite (_ : 2%:R = @rshift 1 _ 1) ?(@rowKd _ 1); last exact: val_inj.
+- rewrite (_ : 2%:R = @rshift 1 _ 1) ?(@rowKd _ 1); first exact: val_inj.
   by rewrite (_ : 1 = @rshift 1 1 0) ?(@rowKd _ 1) ?row_id //; exact: val_inj.
 Qed.
 
@@ -1134,7 +1134,7 @@ have neq_iSSi:  (i + 2%:R != i) && (i + 2%:R != i + 1).
    by case: i neq_iSi => [[|[|[|?]]] ? //=].
 do ![rewrite dotmulE (bigD1 i) // (bigD1 (i + 1)) // (bigD1 (i + 2%:R)) //=;
      rewrite big1 ?mul0r ?addr0 ?mulrDl ?opprD;
-   last by move: i {neq_iSi neq_iSSi}; do 2![move => [[|[|[|?]]] ? //=]]].
+   first by move: i {neq_iSi neq_iSSi}; do 2![move => [[|[|[|?]]] ? //=]]].
 rewrite addrACA mulrAC subrr add0r addrACA -!mulrA -!mulrBr ![w``__ * _]mulrC.
 by congr (_ + _); rewrite -[RHS]mulrN opprB.
 Qed.
@@ -1240,11 +1240,11 @@ Proof.
 pose M (k : 'I_3) : 'M_3 := col_mx3 ('e_k) v w.
 pose Mu12 := col_mx3 (u``_1 *: 'e_1 + u``_2%:R *: 'e_2%:R) v w.
 rewrite (@determinant_multilinear _ _ _ (M 0) Mu12 0 (u``_0) 1) ?mul1r
-        ?row'_col_mx3 //; last first.
+        ?row'_col_mx3 //.
   apply/matrixP => i j; rewrite !mxE !eqxx /tnth /=.
   by case: j => [[|[|[]]]] ? //=; Simp.ord; repeat Simp.r => /=.
 rewrite [\det Mu12](@determinant_multilinear _ _ _
-  (M 1) (M 2%:R) 0 (u``_1) (u``_2%:R)) ?row'_col_mx3 //; last first.
+  (M 1) (M 2%:R) 0 (u``_1) (u``_2%:R)) ?row'_col_mx3 //.
   apply/matrixP => i j; rewrite !mxE !eqxx.
   by case: j => [[|[|[]]]] ? //=; Simp.ord; Simp.r.
 rewrite dotmulE !big_ord_recl big_ord0 addr0 /=.
@@ -1329,11 +1329,11 @@ have [->|neq_ij] := altP (i =P j); rewrite (mulr0n,mulr1n).
   by rewrite scale0r (@liexx _ (vec3 T)).
 apply/rowP => k'; case: (I3P k' neq_ij); rewrite /crossmul; unlock; rewrite !mxE.
 - rewrite (@determinant_alternate _ _ _ 0 1) //=.
-    by move: i j @k neq_ij => [[|[|[|?]]] ?] [[|[|[|?]]] ?] //=; rewrite mulr0.
-  by move=> k''; rewrite !mxE.
+    by move=> k''; rewrite !mxE.
+  by move: i j @k neq_ij => [[|[|[|?]]] ?] [[|[|[|?]]] ?] //=; rewrite mulr0.
 - rewrite (@determinant_alternate _ _ _ 0 2%:R) //=.
-    by move: i j @k neq_ij => [[|[|[|?]]] ?] [[|[|[|?]]] ?] //=; rewrite mulr0.
-  by move=> k''; rewrite !mxE.
+    by move=> k''; rewrite !mxE.
+  by move: i j @k neq_ij => [[|[|[|?]]] ?] [[|[|[|?]]] ?] //=; rewrite mulr0.
 rewrite !eqxx mulr1 -[_ ^ _](@det_perm T) {k k'}; congr (\det _).
 apply/matrixP => a b; rewrite !mxE permE ffunE /=.
 by move: a b i j neq_ij; do 4![move=> [[|[|[|?]]] ?]; rewrite ?mxE //=].
@@ -1358,8 +1358,7 @@ Implicit Types u v w : 'rV[T]_3.
 
 Lemma crossmul_normal u v : u _|_ (u *v v).
 Proof.
-rewrite normalvv crossmul_triple.
-rewrite (determinant_alternate (oner_neq0 _)) => [|i] //.
+rewrite normalvv crossmul_triple (determinant_alternate (oner_neq0 _))=> [i|]//.
 by rewrite !mxE.
 Qed.
 
@@ -1473,19 +1472,19 @@ transitivity (((u``_0)^+2 + (u``_1)^+2 + (u``_2%:R)^+2)
   set C := u0 * v1. set C' := u1 * v0.
   set U0 := u0 ^+ 2. set U1 := u1 ^+ 2. set U2 := u2 ^+ 2.
   set V0 := v0 ^+ 2. set V1 := v1 ^+ 2. set V2 := v2 ^+ 2.
-  rewrite (_ : u0 * v0 * (u1 * v1) = C * C'); last first.
+  rewrite (_ : u0 * v0 * (u1 * v1) = C * C').
     rewrite /C /C' -2!mulrA; congr (_ * _).
     rewrite mulrA mulrC; congr (_ * _); by rewrite mulrC.
   rewrite mulrDl.
-  rewrite (_ : u0 * v0 * (u2 * v2) = B * B'); last first.
+  rewrite (_ : u0 * v0 * (u2 * v2) = B * B').
     rewrite /B /B' [in RHS]mulrC -!mulrA; congr (_ * _).
     rewrite mulrA -(mulrC v2); congr (_ * _); by rewrite mulrC.
-  rewrite (_ : u1 * v1 * (u2 * v2) = A * A'); last first.
+  rewrite (_ : u1 * v1 * (u2 * v2) = A * A').
     rewrite /A /A' -!mulrA; congr (_ * _).
     rewrite mulrA -(mulrC v2); congr (_ * _); by rewrite mulrC.
-  rewrite (_ : (u0 * v0) ^+ 2 = U0 * V0); last by rewrite exprMn.
-  rewrite (_ : (u1 * v1) ^+ 2 = U1 * V1); last by rewrite exprMn.
-  rewrite (_ : (u2 * v2) ^+ 2 = U2 * V2); last by rewrite exprMn.
+  rewrite (_ : (u0 * v0) ^+ 2 = U0 * V0); first by rewrite exprMn.
+  rewrite (_ : (u1 * v1) ^+ 2 = U1 * V1); first by rewrite exprMn.
+  rewrite (_ : (u2 * v2) ^+ 2 = U2 * V2); first by rewrite exprMn.
   rewrite 4![in RHS]opprD.
   (* U0 * V0 *)
   rewrite -3!(addrA (U0 * V0)) -3![in X in _ = _ + X](addrA (- (U0 * V0))).
@@ -1500,12 +1499,12 @@ transitivity (((u``_0)^+2 + (u``_1)^+2 + (u``_2%:R)^+2)
   (* C * C' ^+ 2 *)
   rewrite (addrC (C ^+ 2 - _)) ![in LHS]addrA.
   rewrite (addrC (C * C' *- 2)) ![in RHS]addrA; congr (_ - _).
-  rewrite (_ : U0 * V2 = B' ^+ 2); last by rewrite exprMn.
-  rewrite (_ : U1 * V2 = A ^+ 2); last by rewrite exprMn.
-  rewrite (_ : U0 * V1 = C ^+ 2); last by rewrite exprMn.
-  rewrite (_ : U1 * V0 = C' ^+ 2); last by rewrite exprMn.
-  rewrite (_ : U2 * V0 = B ^+ 2); last by rewrite exprMn.
-  rewrite (_ : U2 * V1 = A' ^+ 2); last by rewrite exprMn.
+  rewrite (_ : U0 * V2 = B' ^+ 2); first by rewrite exprMn.
+  rewrite (_ : U1 * V2 = A ^+ 2); first by rewrite exprMn.
+  rewrite (_ : U0 * V1 = C ^+ 2); first by rewrite exprMn.
+  rewrite (_ : U1 * V0 = C' ^+ 2); first by rewrite exprMn.
+  rewrite (_ : U2 * V0 = B ^+ 2); first by rewrite exprMn.
+  rewrite (_ : U2 * V1 = A' ^+ 2); first by rewrite exprMn.
   (* B' ^+ 2, A ^+ 2 *)
   rewrite -(addrC (B' ^+ 2)) -!addrA; congr (_ + (_ + _)).
   rewrite !addrA.
@@ -1547,9 +1546,9 @@ Lemma dotmul_eq0_crossmul_neq0 (u v : 'rV[T]_3) : u != 0 -> v != 0 ->
 Proof.
 move=> u0 v0 uv0.
 rewrite -enorm_eq0 -(@eqrXn2 _ 2) ?enorm_ge0// exprnP expr0n -exprnP.
-rewrite enorm_crossmul' (eqP uv0) expr0n subr0 -expr0n eqrXn2 //.
-  by rewrite mulf_eq0 negb_or 2!enorm_eq0 u0.
-by rewrite mulr_ge0 ?enorm_ge0.
+rewrite enorm_crossmul' (eqP uv0) expr0n subr0 -expr0n eqrXn2//.
+  by rewrite mulr_ge0 ?enorm_ge0.
+by rewrite mulf_eq0 negb_or 2!enorm_eq0 u0.
 Qed.
 
 End norm3.
@@ -1682,10 +1681,10 @@ rewrite !mulNr !mulrN !opprK.
 rewrite !coefD.
 (* 1 *)
 rewrite [X in X + _ + _](_ : _ = M 0 0 * (M 2%:R 2%:R + M 1 1) +
-   (M 1 1 * M 2%:R 2%:R - M 2%:R 1 * M 1 2%:R)); last first.
+   (M 1 1 * M 2%:R 2%:R - M 2%:R 1 * M 1 2%:R)).
   rewrite coefM sum2E coefD coefX add0r coefN coefC [- _]/=.
   rewrite subn0 coefD coefB.
-  rewrite coefM sum2E subn0 coefD coefX add0r coefN (_ : _`_0 = M 1 1); last by rewrite coefC.
+  rewrite coefM sum2E subn0 coefD coefX add0r coefN (_ : _`_0 = M 1 1); first by rewrite coefC.
   rewrite coefD coefX coefN coefC subr0 mulr1.
   rewrite coefD coefN coefX coefN coefC subr0 mul1r.
   rewrite subnn coefD coefX add0r coefN coefC [in X in - M 1 1 - X]/=.
@@ -1695,7 +1694,7 @@ rewrite [X in X + _ + _](_ : _ = M 0 0 * (M 2%:R 2%:R + M 1 1) +
   rewrite coefD coefX add0r coefN coefC mulrN !mulNr opprK.
   rewrite coefM sum1E coefC coefC [in X in M 1 1 * _ - X]/=.
   by rewrite -opprB mulrN 2!opprK.
-rewrite [X in _ + X + _](_ : _ = - M 0 1 * M 1 0); last first.
+rewrite [X in _ + X + _](_ : _ = - M 0 1 * M 1 0).
   rewrite coefN coefM sum2E coefC [in X in X * _]/= subnn.
   rewrite coefD subn0 coefM sum2E.
   rewrite subn0 subnn coefC coefC mulr0 add0r.
@@ -1703,7 +1702,7 @@ rewrite [X in _ + X + _](_ : _ = - M 0 1 * M 1 0); last first.
   rewrite coefM sum2E subn0 subnn coefC coefD coefX coefN coefC subr0 mulr1.
   rewrite coefC mul0r addr0 coefC mul0r addr0.
   by rewrite mulNr.
-rewrite [X in _ + _ + X](_ : _ = - M 0 2%:R * M 2%:R 0); last first.
+rewrite [X in _ + _ + X](_ : _ = - M 0 2%:R * M 2%:R 0).
   rewrite coefN coefM sum2E subn0 subnn coefC.
   rewrite [in X in X * _]/=.
   rewrite coefD coefM sum2E subn0 coefC coefC mulr0 add0r.
@@ -1755,7 +1754,7 @@ case; last first.
   (* coef3 *)
   rewrite coef_poly !coef_add_poly !coef_opp_poly !coefZ !coefX !coefXn.
   rewrite mulr0 subr0 mulr0 addr0 coefC subr0; apply/eqP.
-  rewrite (_ : _`_3 = lead_coef (char_poly M)); last first.
+  rewrite (_ : _`_3 = lead_coef (char_poly M)).
     by rewrite lead_coefE size_char_poly.
   by rewrite -monicE char_poly_monic.
 (* coef1 *)

--- a/euclidean.v
+++ b/euclidean.v
@@ -1,6 +1,6 @@
 (* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From HB Require Import structures.
-From mathcomp Require Import all_boot all_order ssralg ssrint ssrnum rat poly.
+From mathcomp Require Import boot order ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import sesquilinear.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import realalg complex fingroup perm.
@@ -175,9 +175,7 @@ Notation "*d%R" := (@dotmul _ _) : ring_scope.
 Notation "u *d w" := (dotmul u w) : ring_scope.
 
 Section com_dot_product.
-
 Variables (R : comPzRingType) (n : nat).
-
 Implicit Types u v : 'rV[R]_n.
 
 Lemma dotmulC u v : u *d v = v *d u.
@@ -188,6 +186,12 @@ Proof. by rewrite dotmulDr 2!dotmulDl mulr2n !addrA ![v *d _]dotmulC. Qed.
 
 Lemma dotmulvZ u k v : u *d (k *: v) = k * (u *d v).
 Proof. by rewrite /dotmul linearZ /= -scalemxAr mxE. Qed.
+
+Lemma dotmul_is_linear u : linear (dotmul u : 'rV[R]_n -> R^o).
+Proof. move=> /= k v w; by rewrite dotmulDr dotmulvZ. Qed.
+
+HB.instance Definition _ x :=
+  GRing.isLinear.Build _ _ _ _ (@dotmul R n x) (dotmul_is_linear x).
 
 Lemma dotmul_trmx u M v : u *d (v *m M) = (u *m M^T) *d v.
 Proof. by rewrite /dotmul trmx_mul mulmxA. Qed.
@@ -201,18 +205,11 @@ Structure revop X Y Z (f : Y -> X -> Z) := RevOp {
 }.
 
 Section dotmul_bilinear_Pz.
-
 Variables (R : comPzRingType) (n : nat).
 
 Definition dotmul_rev (v u : 'rV[R]_n) := u *d v.
 (*Canonical rev_dotmul := @RevOp _ _ _ dotmul_rev (@dotmul R n)
   (fun _ _ => erefl).*)
-
-Lemma dotmul_is_linear u : linear (dotmul u : 'rV[R]_n -> R^o).
-Proof. move=> /= k v w; by rewrite dotmulDr dotmulvZ. Qed.
-
-HB.instance Definition _ x :=
-  GRing.isLinear.Build _ _ _ _ (@dotmul R n x) (dotmul_is_linear x).
 
 Lemma dotmul_rev_is_linear v : linear (dotmul_rev v : 'rV[R]_n -> R^o).
 Proof. move=> /= k u w; by rewrite /dotmul_rev dotmulDl dotmulZv. Qed.
@@ -235,12 +232,9 @@ split => [u'|u] a x y /=.
 Qed.
 
 HB.instance Definition _ :=
-  bilinear_isBilinear.Build R
-    [the lmodType R of 'rV[R]_n] [the lmodType R of 'rV[R]_n]
-    R^o _ _ (@dotmul R n) dotmul_is_bilinear.
+  bilinear_isBilinear.Build R _ _ _ _ _ (@dotmul R n) dotmul_is_bilinear.
 
 End dotmul_bilinear_Nz.
-
 Section dot_product.
 
 Variables (T : realDomainType) (n : nat).
@@ -258,11 +252,9 @@ move/allP => H; apply/eqP/rowP => i.
 apply/eqP; by rewrite mxE -sqrf_eq0 expr2 -(implyTb ( _ == _)) H.
 Qed.
 
-Lemma dotmul_is_hermitian x y :
+Let dotmul_is_hermitian x y :
   (@dotmul T n) x y = (-1) ^+ false * idfun ((@dotmul T n) y x).
-Proof.
-by rewrite /= expr0 mul1r dotmulC.
-Qed.
+Proof. by rewrite /= expr0 mul1r dotmulC. Qed.
 
 HB.instance Definition _ :=
   @isHermitianSesquilinear.Build _ _ _ _ _ dotmul_is_hermitian.
@@ -490,7 +482,7 @@ Proof. by rewrite orthogonalE trmx1 mulr1. Qed.
 Lemma orthogonal_mul_tr M : (M \is 'O[T]_n) -> M *m M^T = 1.
 Proof. by move/eqP. Qed.
 
-Lemma orthogonal_oppr_closed : oppr_closed 'O[T]_n.
+Let orthogonal_oppr_closed : oppr_closed 'O[T]_n.
 Proof. by move=> x; rewrite !orthogonalE linearN /= mulNr mulrN opprK. Qed.
 
 HB.instance Definition _ := GRing.isOppClosed.Build _ _ orthogonal_oppr_closed.
@@ -553,14 +545,15 @@ Proof. by rewrite -orthogonalV orthogonalE trmxK. Qed.
 Lemma orthogonal_tr_mul M : (M \is 'O[T]_n) -> M^T *m M = 1.
 Proof. by rewrite orthogonalEC => /eqP. Qed.
 
-Lemma orthogonal_divr_closed : divr_closed (orthogonal n T).
+Let orthogonal_divr_closed : divr_closed (orthogonal n T).
 Proof.
 split => [| P Q HP HQ]; first exact: orthogonal1.
 rewrite orthogonalE orthogonal_inv // trmx_mul trmxK -mulrA.
 by rewrite -orthogonal_inv // mulKr // orthogonal_unit.
 Qed.
 
-HB.instance Definition _ := GRing.isDivClosed.Build _ (@orthogonal_pred n T) orthogonal_divr_closed.
+HB.instance Definition _ :=
+  GRing.isDivClosed.Build _ (@orthogonal_pred n T) orthogonal_divr_closed.
 
 Lemma orthogonal_mulr_2closed : GRing.mulr_2closed 'O[T]_n.
 Proof.
@@ -592,16 +585,17 @@ Proof. apply/andP; by rewrite orthogonal1 det1. Qed.
 Lemma rotation_tr_mul M : (M \is 'SO[T]_n) -> M^T *m M = 1.
 Proof. by move=> /rotation_sub /orthogonal_tr_mul. Qed.
 
-Lemma rotation_divr_closed : divr_closed 'SO[T]_n.
+Let rotation_divr_closed : divr_closed 'SO[T]_n.
 Proof.
 split => [|P Q Prot Qrot]; first exact: rotation1.
 rewrite rotationE rpred_div ?rotation_sub //=.
 by rewrite det_mulmx det_inv !rotation_det // divr1.
 Qed.
 
-HB.instance Definition _ := GRing.isDivClosed.Build _ (@rotation_pred n T) rotation_divr_closed.
+HB.instance Definition _ :=
+  GRing.isDivClosed.Build _ (@rotation_pred n T) rotation_divr_closed.
 
-Lemma rotation_mulr_2closed : GRing.mulr_2closed 'SO[T]_n.
+Let rotation_mulr_2closed : GRing.mulr_2closed 'SO[T]_n.
 Proof.
 move=> M N MSO NSO.
 rewrite rotationE rpredM//=.
@@ -610,10 +604,8 @@ rewrite rotationE rpredM//=.
 by rewrite detM rotation_det// rotation_det// mulr1.
 Qed.
 
-HB.instance Definition _ := GRing.isMul2Closed.Build _ 'SO[T]_n rotation_mulr_2closed.
-
-(*Canonical rotation_is_mulr_closed := MulrPred rotation_divr_closed.
-Canonical rotation_is_divr_closed := DivrPred rotation_divr_closed.*)
+HB.instance Definition _ :=
+  GRing.isMul2Closed.Build _ 'SO[T]_n rotation_mulr_2closed.
 
 Lemma orthogonalPcol M :
   reflect (forall i j, (col i M)^T *d (col j M)^T = (i == j)%:R) (M \is 'O[T]_n).
@@ -1150,7 +1142,8 @@ rewrite (@determinant_multilinear _ _ (M _) (M v) (M w) 2%:R a 1);
 by apply/rowP => j; rewrite !mxE.
 Qed.
 
-HB.instance Definition _ u := GRing.isLinear.Build _ _ _ _ (crossmul u) (crossmul_linear u).
+HB.instance Definition _ u :=
+  GRing.isLinear.Build _ _ _ _ (crossmul u) (crossmul_linear u).
 
 (*Canonical crossmul_is_additive u := Additive (crossmul_linear u).
 Canonical crossmul_is_linear u := AddLinear (crossmul_linear u).*)
@@ -1168,7 +1161,8 @@ rewrite (@determinant_multilinear _ _ _ (M v) (M w) 1%:R a 1);
 by apply/rowP => j; rewrite !mxE.
 Qed.
 
-HB.instance Definition _ u := GRing.isLinear.Build _ _ _ _ (crossmulr u) (crossmulr_linear u).
+HB.instance Definition _ u :=
+  GRing.isLinear.Build _ _ _ _ (crossmulr u) (crossmulr_linear u).
 
 End crossmullie_Pz.
 
@@ -1187,13 +1181,7 @@ split => [u'|u] a x y /=.
 Qed.
 
 HB.instance Definition _ :=
-  bilinear_isBilinear.Build R
-    [the lmodType R of 'rV[R]_3] [the lmodType R of 'rV[R]_3]
-    [the lmodType R of 'rV[R]_3] _ _ (@crossmul R) crossmul_is_bilinear.
-
-(*Canonical crossmulr_is_additive u := Additive (crossmulr_linear u).
-Canonical crossmulr_is_linear u := AddLinear (crossmulr_linear u).
-Canonical crossmul_bilinear := [bilinear of (@crossmul R)].*)
+  bilinear_isBilinear.Build _ _ _ _ _ _ (@crossmul R) crossmul_is_bilinear.
 
 End crossmullie_Nz.
 
@@ -1220,13 +1208,13 @@ rewrite -!addrA addrC -!addrA (dotmulC w u) -(addrC (_ *: v)) subrr addr0.
 by rewrite addrC dotmulC subrr.
 Qed.
 
-HB.instance Definition _ :=
-  @isLieAlgebra.Build R (vec3 R) (@crossmul R : {bilinear (vec3 R) -> (vec3 R) -> (vec3 R)}) liexx jacobi.
+HB.instance Definition _ := @isLieAlgebra.Build R (vec3 R)
+  (@crossmul R : {bilinear (vec3 R) -> (vec3 R) -> (vec3 R)}) liexx jacobi.
 
 End rv3liealgebra.
 
 Section crossmul_lemmas.
-Variable R : comNzRingType.
+Context {R : comNzRingType}.
 Implicit Types u v w : 'rV[R]_3.
 
 Lemma mulmxl_crossmulr M u v : M *m (u *v v) = u *v (M *m v).

--- a/extra_trigo.v
+++ b/extra_trigo.v
@@ -1,4 +1,4 @@
-From mathcomp Require Import all_boot all_order ssralg ssrnum.
+From mathcomp Require Import boot order ssralg ssrnum.
 From mathcomp Require Import boolp interval reals trigo.
 Require Import ssr_ext.
 

--- a/extra_trigo.v
+++ b/extra_trigo.v
@@ -175,11 +175,9 @@ Qed.
 Lemma sin_norm_angle a : sin (norm_angle a) = sin a.
 Proof.
 rewrite /norm_angle.
-case: ltP => [sa_lt0|sa_gt0]; rewrite ?sinN sin_acos.
-  rewrite -sin2cos2 sqrtr_sqr ltr0_norm // opprK //.
-  by rewrite cos_geN1 cos_le1.
-rewrite -sin2cos2 sqrtr_sqr ger0_norm //.
-by rewrite cos_geN1 cos_le1.
+case: ltP => [sa_lt0|sa_gt0]; rewrite ?sinN sin_acos ?(cos_geN1, cos_le1) //.
+  by rewrite -sin2cos2 sqrtr_sqr ltr0_norm // opprK.
+by rewrite -sin2cos2 sqrtr_sqr ger0_norm.
 Qed.
 
 Lemma norm_angle_lepi a : norm_angle a <= pi.
@@ -221,7 +219,7 @@ move=> aB; rewrite /norm_angle; case: (ltP a 0) => [a_lt0|a_ge0]; last first.
   by rewrite ltNge sin_ge0_pi /= ?cosK.
 have aB1 : - pi < a < 0 by rewrite a_lt0 andbT; case/andP: aB.
 have aB2 : - pi <= a <= 0 by case/andP: aB1 => *; rewrite !ltW.
-rewrite -oppr_cp0 -sinN sin_gt0_pi; last by rewrite oppr_cp0 andbC ltrNl.
+rewrite -oppr_cp0 -sinN sin_gt0_pi; first by rewrite oppr_cp0 andbC ltrNl.
 by rewrite -cosN cosK ?opprK // in_itv/= oppr_cp0 andbC lerNl.
 Qed.
 
@@ -264,8 +262,8 @@ have /divrr H : 1 + x ^+ 2 \in GRing.unit.
   by rewrite unitfE gt_eqF // -(addr0 0) ltr_leD // ?ltr01 // sqr_ge0.
 rewrite -{2}H {H} addrC mulNr -mulrBl -invf_div -[LHS]invrK; congr (_ ^-1).
 rewrite -exprVn -div1r expr_div_n expr1n cos2_tan2.
-  by rewrite atanK addrK divr1 mul1r.
-by rewrite gt_eqF // cos_gt0_pihalf // atan_ltpi2 atan_gtNpi2.
+  by rewrite gt_eqF // cos_gt0_pihalf // atan_ltpi2 atan_gtNpi2.
+by rewrite atanK addrK divr1 mul1r.
 Qed.
 
 Lemma ltr_atan : {mono (@atan R) : x y / x < y >-> x < y}.
@@ -278,7 +276,7 @@ Lemma sin_atan_ltr0 (x : R) : x < 0 -> sin (atan x) < 0.
 Proof.
 move=> x0.
 rewrite -[X in X < _]opprK -sinN oppr_cp0 sin_gt0_pi //.
-rewrite oppr_cp0 ltrNl andbC (lt_trans _ (atan_gtNpi2 _)) /=; last first.
+rewrite oppr_cp0 ltrNl andbC (lt_trans _ (atan_gtNpi2 _)) /=.
   rewrite ltrNl opprK ltr_pdivrMr ?ltr0n // mulr_natr mulr2n.
   by rewrite -subr_gt0 addrK pi_gt0.
 by rewrite -atan0 ltr_atan.
@@ -296,11 +294,11 @@ apply/eqP.
 case/boolP : (x == 0) => [/eqP ->|].
   by rewrite atan0 sin0 mul0r.
 move/lt_total => /orP [] x0.
-  rewrite -eqr_opp -(@eqrXn2 _ 2) //; last 2 first.
+  rewrite -eqr_opp -(@eqrXn2 _ 2) //.
     move/sin_atan_ltr0 : x0; by rewrite oppr_ge0 => /ltW.
     by rewrite -mulNr divr_ge0 // ?sqrtr_ge0 // oppr_ge0 ltW.
   by rewrite 2!sqrrN sqr_sin_atan exprMn exprVn sqr_sqrtr // addr_ge0 // ?ler01 // sqr_ge0.
-rewrite -(@eqrXn2 _ 2) //; last 2 first.
+rewrite -(@eqrXn2 _ 2) //.
   by rewrite ltW // sin_atan_gtr0.
   by rewrite mulr_ge0 // ?invr_ge0 ?sqrtr_ge0 // ltW.
 by rewrite sqr_sin_atan exprMn exprVn sqr_sqrtr // addr_ge0 // ?ler01 // sqr_ge0.
@@ -349,7 +347,7 @@ Qed.
 
 Lemma atan2_N1N1 : atan2 (- 1) (- 1) = - (pi / 4%:R) *+ 3.
 Proof.
-rewrite /atan2 ltr0N1 ltrN10 ler0N1 divrr; last first.
+rewrite /atan2 ltr0N1 ltrN10 ler0N1 divrr.
   by rewrite unitfE eqr_oppLR oppr0 oner_neq0.
 rewrite atan1 -[RHS]mulr_natr.
 have -> : 3%:R = 4%:R - 1%:R :> R by rewrite -natrB.
@@ -362,7 +360,7 @@ Lemma sqrtr_sqrN2 (x : R) : x != 0 -> Num.sqrt (x ^- 2) = `|x|^-1.
 Proof.
 move=> x0.
 apply (@mulrI _ `|x|); first by rewrite unitfE normr_eq0.
-rewrite -{1}(sqrtr_sqr x) -sqrtrM ?sqr_ge0 // divrr; last by rewrite unitfE normr_eq0.
+rewrite -{1}(sqrtr_sqr x) -sqrtrM ?sqr_ge0 // divrr; first by rewrite unitfE normr_eq0.
 by rewrite divrr ?sqrtr1 // unitfE sqrf_eq0.
 Qed.
 
@@ -401,8 +399,7 @@ Lemma inv_yarc (x : R) : `| x | < 1 -> (yarc x)^-1 = Num.sqrt (1 - x ^+ 2)^-1.
 Proof.
 move=> x1.
 apply (@mulrI _ (yarc x)); first by rewrite unitfE yarc_neq0.
-rewrite divrr; last by rewrite unitfE yarc_neq0.
-rewrite -sqrtrM; last by rewrite ltW // N1x2_gt0.
+rewrite divrr ?unitfE ?yarc_neq0// -sqrtrM ?ltW ?N1x2_gt0//.
 by rewrite divrr ?sqrtr1 // unitfE gt_eqF // N1x2_gt0.
 Qed.
 
@@ -431,9 +428,9 @@ rewrite neq_lt => /orP[] y0.
   case: (lerP 0 x) => x0.
     rewrite atan2_ge0_lt0E // cosDpi ?eqxx // cos_atan expr_div_n.
     abstract: H.
-    rewrite -{1}(@divrr _ (y ^+ 2)); last by rewrite unitfE sqrf_eq0 lt_eqF.
-    rewrite -mulrDl sqrtrM; last by rewrite addr_ge0 // sqr_ge0.
-    rewrite sqrtr_sqrN2 ?lt_eqF // ltr0_norm // invrM; last 2 first.
+    rewrite -{1}(@divrr _ (y ^+ 2)) ?unitfE ?sqrf_eq0 ?lt_eqF//.
+    rewrite -mulrDl sqrtrM ?addr_ge0 ?sqr_ge0//.
+    rewrite sqrtr_sqrN2 ?lt_eqF // ltr0_norm // invrM.
       by rewrite unitfE sqrtr_eq0 -ltNge ltr_wpDr // ?sqr_ge0 // exprn_even_gt0 // orbC lt_eqF.
       by rewrite unitfE invr_eq0 eqr_oppLR oppr0 lt_eqF.
     by rewrite !invrN invrK mulNr opprK.
@@ -441,8 +438,8 @@ rewrite neq_lt => /orP[] y0.
   rewrite cos_atan expr_div_n.
   exact: H.
 rewrite {1}atan2_x_gt0E // cos_atan.
-rewrite -{1}(@divrr _ (y ^+ 2)); last by rewrite unitfE sqrf_eq0 gt_eqF.
-rewrite expr_div_n -mulrDl sqrtrM; last by rewrite addr_ge0 // sqr_ge0.
+rewrite -{1}(@divrr _ (y ^+ 2)) ?unitfE ?sqrf_eq0 ?gt_eqF//.
+rewrite expr_div_n -mulrDl sqrtrM ?addr_ge0 ?sqr_ge0//.
 rewrite sqrtr_sqrN2 ?gt_eqF // gtr0_norm // invrM ?invrK //.
 by rewrite unitfE sqrtr_eq0 -ltNge ltr_wpDr // ?sqr_ge0 // exprn_gt0.
 by rewrite unitfE invr_neq0 // gt_eqF.
@@ -471,9 +468,9 @@ rewrite neq_lt => /orP[] y0.
   case: (lerP 0 x) => x0.
     rewrite atan2_ge0_lt0E // sinDpi ?eqxx // sin_atan expr_div_n.
     abstract: H.
-    rewrite -{1}(@divrr _ (y ^+ 2)); last by rewrite unitfE sqrf_eq0 lt_eqF.
-    rewrite -mulrDl sqrtrM; last by rewrite addr_ge0 // sqr_ge0.
-    rewrite sqrtr_sqrN2 ?lt_eqF // ltr0_norm // invrM; last 2 first.
+    rewrite -{1}(@divrr _ (y ^+ 2)) ?unitfE ?sqrf_eq0 ?lt_eqF//.
+    rewrite -mulrDl sqrtrM ?addr_ge0 ?sqr_ge0//.
+    rewrite sqrtr_sqrN2 ?lt_eqF // ltr0_norm // invrM.
       by rewrite unitfE sqrtr_eq0 -ltNge ltr_wpDr // ?sqr_ge0 // exprn_even_gt0 // orbC lt_eqF.
       by rewrite unitfE invr_eq0 eqr_oppLR oppr0 lt_eqF.
     rewrite !invrN invrK mulNr mulrN opprK -mulrA (mulrA _^-1) mulVf ?mul1r //.
@@ -482,8 +479,8 @@ rewrite neq_lt => /orP[] y0.
   rewrite sin_atan expr_div_n.
   exact: H.
 rewrite {1}atan2_x_gt0E // sin_atan.
-rewrite -{1}(@divrr _ (y ^+ 2)); last by rewrite unitfE sqrf_eq0 gt_eqF.
-rewrite expr_div_n -mulrDl sqrtrM; last by rewrite addr_ge0 // sqr_ge0.
+rewrite -{1}(@divrr _ (y ^+ 2)) ?unitfE ?sqrf_eq0 ?gt_eqF//.
+rewrite expr_div_n -mulrDl sqrtrM ?addr_ge0 ?sqr_ge0//.
 rewrite sqrtr_sqrN2 ?gt_eqF // gtr0_norm // invf_div mulrA divfK //.
 by case: ltgtP y0.
 Qed.

--- a/frame.v
+++ b/frame.v
@@ -201,7 +201,7 @@ do 3 rewrite dotmulE sum3E.
 move=> H1 H2 H3.
 have /eqP : p *m (col_mx3 f~i f~j f~k) ^T = 0.
   by rewrite mul_tr_col_mx3 dotmulE sum3E H1 dotmulE sum3E H2 dotmulE sum3E H3 row30.
-rewrite mul_mx_rowfree_eq0; first by move/eqP.
+rewrite mul_mx_rowfree_eq0; last by move/eqP.
 apply/row_freeP; exists (col_mx3 f~i f~j f~k).
 by apply/eqP; rewrite -orthogonalEC !rowframeE col_mx3_row (NOFrame.MO _).
 Qed.
@@ -238,23 +238,23 @@ rewrite (@lieC _ (vec3 T) _ f~j).
 rewrite (@lieC _ (vec3 T) _ f~k).
 rewrite /=.
 rewrite ![in LHS]linearD /=.
-rewrite (_ : _ *v _ = 0); last by rewrite linearZ /= (@liexx _ (vec3 T)) scaler0.
+rewrite (_ : _ *v _ = 0); first by rewrite linearZ /= (@liexx _ (vec3 T)) scaler0.
 rewrite oppr0 scaler0 add0r.
 case: noframek => e3e1e2.
 - case: (noframe_posP e3e1e2) => Hj Hi.
-  rewrite (_ : _ *v _ = v2 *: f~k); last by rewrite linearZ /= -e3e1e2.
-  rewrite scalerN (_ : _ *v _ = - v3 *: f~j); last first.
+  rewrite (_ : _ *v _ = v2 *: f~k); first by rewrite linearZ /= -e3e1e2.
+  rewrite scalerN (_ : _ *v _ = - v3 *: f~j).
     by rewrite linearZ /= (@lieC _ (vec3 T)) /= -Hj scalerN scaleNr.
-  rewrite scaleNr opprK (_ : _ *v _ = - v1 *: f~k); last first.
+  rewrite scaleNr opprK (_ : _ *v _ = - v1 *: f~k).
     by rewrite linearZ /= (@lieC _ (vec3 T)) e3e1e2 scalerN scaleNr.
-  rewrite scaleNr opprK (_ : _ *v _ = 0); last first.
+  rewrite scaleNr opprK (_ : _ *v _ = 0).
     by rewrite linearZ /= (@liexx _ (vec3 T)) scaler0.
   rewrite scalerN scaler0 subr0.
-  rewrite (_ : _ *v _ = v3 *: f~i); last by rewrite linearZ /= -Hi.
-  rewrite scalerN (_ : _ *v _ = v1 *: f~j); last by rewrite linearZ /= Hj.
-  rewrite scalerN (_ : _ *v _ = - v2 *: f~i); last first.
+  rewrite (_ : _ *v _ = v3 *: f~i); first by rewrite linearZ /= -Hi.
+  rewrite scalerN (_ : _ *v _ = v1 *: f~j); first by rewrite linearZ /= Hj.
+  rewrite scalerN (_ : _ *v _ = - v2 *: f~i).
     by rewrite linearZ /= (@lieC _ (vec3 T)) /= -Hi scaleNr scalerN.
-  rewrite scaleNr opprK (_ : _ *v _ = 0); last first.
+  rewrite scaleNr opprK (_ : _ *v _ = 0).
     by rewrite linearZ /= (@liexx _ (vec3 T)) scaler0.
   rewrite scalerN scaler0 subr0.
   move/esym : noframe_pos; rewrite e3e1e2 eqxx => /eqP ->.
@@ -263,39 +263,40 @@ case: noframek => e3e1e2.
   rewrite addrCA.
   rewrite addrC.
   rewrite ![in LHS]addrA.
-  rewrite -addrA; congr (_ + _); last first.
+  rewrite -(addrA _ _ (w2 *: (v1 *: (f|,0 *v f|,1)))); congr (_ + _); last first.
     by rewrite !scalerA -scaleNr -scalerDl /= addrC mulrC (mulrC w1).
   rewrite -addrA addrACA addrC; congr (_ + _).
     by rewrite -scaleNr !scalerA -scalerDl addrC mulrC mulNr (mulrC w2).
   by rewrite !scalerA -scalerBl scalerN -scaleNr opprB mulrC (mulrC w3).
 - case: (noframe_negP e3e1e2) => Hj Hi.
-  rewrite (_ : _ *v _ = - v2 *: f~k); last first.
+  rewrite (_ : _ *v _ = - v2 *: f~k).
     rewrite linearZ /= e3e1e2.
     rewrite (linearNl _ f|,1)/=.
     by rewrite scalerN scaleNr opprK.
   rewrite scaleNr opprK.
-  rewrite (_ : _ *v _ = v3 *: f~j); last by rewrite linearZ /= -Hj.
+  rewrite (_ : _ *v _ = v3 *: f~j); first by rewrite linearZ /= -Hj.
   rewrite scalerN.
-  rewrite (_ : _ *v _ = v1 *: f~k); last first.
+  rewrite (_ : _ *v _ = v1 *: f~k).
     by rewrite linearZ /= (@lieC _ (vec3 T)) -linearNl /= -e3e1e2.
   rewrite scalerN.
-  rewrite (_ : _ *v _ = 0); last by rewrite linearZ /= (@liexx _ (vec3 T)) scaler0.
+  rewrite (_ : _ *v _ = 0); first by rewrite linearZ /= (@liexx _ (vec3 T)) scaler0.
   rewrite oppr0 scaler0 addr0.
-  rewrite (_ : _ *v _ = - v3 *: f~i); last first.
+  rewrite (_ : _ *v _ = - v3 *: f~i).
     by rewrite linearZ /= (@lieC _ (vec3 T)) /= -Hi scalerN scaleNr.
   rewrite scaleNr opprK.
-  rewrite (_ : _ *v _ = - v1 *: f~j); last first.
+  rewrite (_ : _ *v _ = - v1 *: f~j).
     by rewrite linearZ /= (@lieC _ (vec3 T)) /= -Hj scalerN scaleNr.
   rewrite scaleNr opprK.
-  rewrite (_ : _ *v _ = v2 *: f~i); last by rewrite linearZ /= -Hi.
+  rewrite (_ : _ *v _ = v2 *: f~i); first by rewrite linearZ /= -Hi.
   rewrite scalerN.
-  rewrite (_ : _ *v _ = 0); last by rewrite linearZ /= (@liexx _ (vec3 T)) scaler0.
+  rewrite (_ : _ *v _ = 0); first by rewrite linearZ /= (@liexx _ (vec3 T)) scaler0.
   rewrite oppr0 scaler0 addr0.
   move: noframe_neg; rewrite {1}e3e1e2 eqxx => /esym/eqP ->.
   rewrite -![in LHS]addrA addrC -addrA.
-  rewrite addrCA -addrA addrC ![in LHS]addrA -addrA; congr (_ + _); last first.
+  rewrite addrCA -addrA addrC ![in LHS]addrA.
+  rewrite -(addrA _ _ (- (w2 *: (v1 *: f|,2)))); congr (_ + _); last first.
     by rewrite !scalerA -scalerBl mulrN1 opprB mulrC (mulrC w2).
-  rewrite -addrA addrACA; congr (_ + _).
+  rewrite -(addrA _ _ (- (w1 *: (v3 *: f|,1)))) addrACA; congr (_ + _).
     by rewrite !scalerA -scalerBl mulrN1 opprB mulrC (mulrC w3).
   by rewrite !scalerA -scalerBl scalerN mulrN1 scaleNr opprK mulrC (mulrC w1).
 Qed.
@@ -516,7 +517,7 @@ Proof. by rewrite /j colinearNv normalcompvN. Qed.
 
 Lemma kN : k (- u) = - k u.
 Proof.
-by rewrite /k (_ : j (- u) = j u); [rewrite (linearNl _ (j u)) | rewrite -jN].
+by rewrite /k (_ : j (- u) = j u); [rewrite -jN | rewrite (linearNl _ (j u))].
 Qed.
 
 End base1_lemmas.
@@ -821,7 +822,7 @@ Qed.
 
 Lemma FromTo_comp A B C : (C _R^ B) *m (B _R^ A) = C _R^ A.
 Proof.
-rewrite 2!FromToE -mulmxA (mulmxA _ B) mulVmx; last first.
+rewrite 2!FromToE -mulmxA (mulmxA _ B) mulVmx.
   by rewrite unitmxE (rotation_det (Frame.MSO B)) unitr1.
 rewrite mul1mx; apply/matrixP => i j.
 rewrite !mxE dotmulE; apply/eq_bigr => k _.
@@ -971,7 +972,7 @@ Proof. by rewrite -enorm_eq0 normi oner_neq0. Qed.
 
 Lemma normj : `| j |_e = 1.
 Proof.
-rewrite /j norm_normalize // normalcomp_colinear; last first.
+rewrite /j norm_normalize // normalcomp_colinear.
   by rewrite -enorm_eq0 normi oner_neq0.
 apply: contra (abc); rewrite colinearvZ invr_eq0 enorm_eq0 subr_eq0.
 by rewrite eq_sym (negPf ab) /= colinear_sym.

--- a/frame.v
+++ b/frame.v
@@ -1,6 +1,6 @@
 (* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From HB Require Import structures.
-From mathcomp Require Import all_boot all_order ssralg ssrint ssrnum rat poly.
+From mathcomp Require Import boot order ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import sesquilinear.
 From mathcomp Require Import realalg complex fingroup perm reals.

--- a/meta.yml
+++ b/meta.yml
@@ -29,11 +29,11 @@ license:
   identifier: LGPL-2.1-or-later
   file: LICENSE
 
-supported_coq_versions:
+supported_rocq_versions:
   text: Rocq 9.0--9.3
   opam: '{ (>= "9.1" & < "9.4~") }'
 
-tested_coq_opam_versions:
+tested_rocq_opam_versions:
 - version: 'rocq-prover-9.1'
   repo: 'mathcomp/mathcomp-dev'
 
@@ -45,45 +45,40 @@ dependencies:
     [Hierarchy Builder](https://github.com/math-comp/hierarchy-builder)
 
 - opam:
-    name: coq-mathcomp-ssreflect
+    name: rocq-mathcomp-ssreflect
     version: '{ (>= "2.6.0") | (= "dev") }'
   description: |-
     [MathComp ssreflect](https://math-comp.github.io)
 - opam:
-    name: coq-mathcomp-fingroup
+    name: rocq-mathcomp-fingroup
     version: '{ (>= "2.6.0") | (= "dev") }'
   description: |-
     [MathComp fingroup](https://math-comp.github.io)
 - opam:
-    name: coq-mathcomp-algebra
+    name: rocq-mathcomp-algebra
     version: '{ (>= "2.6.0") | (= "dev") }'
   description: |-
     [MathComp algebra](https://math-comp.github.io)
 - opam:
-    name: coq-mathcomp-solvable
+    name: rocq-mathcomp-solvable
     version: '{ (>= "2.6.0") | (= "dev") }'
   description: |-
     [MathComp solvable](https://math-comp.github.io)
 - opam:
-    name: coq-mathcomp-field
+    name: rocq-mathcomp-field
     version: '{ (>= "2.6.0") | (= "dev") }'
   description: |-
     [MathComp field](https://math-comp.github.io)
 - opam:
-    name: coq-mathcomp-analysis
+    name: rocq-mathcomp-analysis
     version: '{ (>= "1.17.0") | (= "dev") }'
   description: |-
     [MathComp analysis](https://github.com/math-comp/analysis)
 - opam:
-    name: coq-mathcomp-real-closed
-    version: '{ (>= "2.0.5") | (= "dev") }'
+    name: rocq-mathcomp-real-closed
+    version: '{ (>= "2.0.6") | (= "dev") }'
   description: |-
     [MathComp real closed](https://github.com/math-comp/real-closed)
-- opam:
-    name: coq-mathcomp-algebra-tactics
-    version: '{ (>= "1.2.4") | (= "dev") }'
-  description: |-
-    [MathComp algebra tactics](https://github.com/math-comp/algebra-tactics)
 
 namespace: robot
 

--- a/meta.yml
+++ b/meta.yml
@@ -35,7 +35,7 @@ supported_rocq_versions:
 
 tested_rocq_opam_versions:
 - version: 'rocq-prover-9.1'
-  repo: 'mathcomp/mathcomp-dev'
+  repo: 'mathcomp/mathcomp'
 
 dependencies:
 - opam:

--- a/meta.yml
+++ b/meta.yml
@@ -34,7 +34,8 @@ supported_rocq_versions:
   opam: '{ (>= "9.1" & < "9.4~") }'
 
 tested_rocq_opam_versions:
-- version: 'rocq-prover-9.1'
+- version: '9.1'
+- version: '9.2'
 
 dependencies:
 - opam:

--- a/meta.yml
+++ b/meta.yml
@@ -35,7 +35,6 @@ supported_rocq_versions:
 
 tested_rocq_opam_versions:
 - version: '9.1'
-- version: '9.2'
 
 dependencies:
 - opam:

--- a/meta.yml
+++ b/meta.yml
@@ -40,43 +40,43 @@ tested_rocq_opam_versions:
 dependencies:
 - opam:
     name: rocq-hierarchy-builder
-    version: '{ (>= "1.10.0") | (= "dev") }'
+    version: '{ (>= "1.10.0") }'
   description: |-
     [Hierarchy Builder](https://github.com/math-comp/hierarchy-builder)
 
 - opam:
     name: rocq-mathcomp-ssreflect
-    version: '{ (>= "2.6.0") | (= "dev") }'
+    version: '{ (>= "2.6.0") }'
   description: |-
     [MathComp ssreflect](https://math-comp.github.io)
 - opam:
     name: rocq-mathcomp-fingroup
-    version: '{ (>= "2.6.0") | (= "dev") }'
+    version: '{ (>= "2.6.0") }'
   description: |-
     [MathComp fingroup](https://math-comp.github.io)
 - opam:
     name: rocq-mathcomp-algebra
-    version: '{ (>= "2.6.0") | (= "dev") }'
+    version: '{ (>= "2.6.0") }'
   description: |-
     [MathComp algebra](https://math-comp.github.io)
 - opam:
     name: rocq-mathcomp-solvable
-    version: '{ (>= "2.6.0") | (= "dev") }'
+    version: '{ (>= "2.6.0") }'
   description: |-
     [MathComp solvable](https://math-comp.github.io)
 - opam:
     name: rocq-mathcomp-field
-    version: '{ (>= "2.6.0") | (= "dev") }'
+    version: '{ (>= "2.6.0") }'
   description: |-
     [MathComp field](https://math-comp.github.io)
 - opam:
     name: rocq-mathcomp-analysis
-    version: '{ (>= "1.17.0") | (= "dev") }'
+    version: '{ (>= "1.17.0") }'
   description: |-
     [MathComp analysis](https://github.com/math-comp/analysis)
 - opam:
     name: rocq-mathcomp-real-closed
-    version: '{ (>= "2.0.6") | (= "dev") }'
+    version: '{ (>= "2.0.6") }'
   description: |-
     [MathComp real closed](https://github.com/math-comp/real-closed)
 

--- a/meta.yml
+++ b/meta.yml
@@ -29,60 +29,59 @@ license:
   identifier: LGPL-2.1-or-later
   file: LICENSE
 
-supported_rocq_versions:
+supported_coq_versions:
   text: Rocq 9.0--9.3
-  opam: '{ (>= "9.0" & < "9.4") }'
+  opam: '{ (>= "9.1" & < "9.4~") }'
 
-tested_rocq_opam_versions:
-- version: '2.5.0-rocq-prover-9.0'
-  repo: 'mathcomp/mathcomp'
-- version: '2.5.0-rocq-prover-9.1'
-  repo: 'mathcomp/mathcomp'
+tested_coq_opam_versions:
+- version: 'rocq-prover-9.1'
+  repo: 'mathcomp/mathcomp-dev'
 
 dependencies:
 - opam:
     name: rocq-hierarchy-builder
-    version: '{ (>= "1.10.0") }'
+    version: '{ (>= "1.10.0") | (= "dev") }'
   description: |-
     [Hierarchy Builder](https://github.com/math-comp/hierarchy-builder)
+
 - opam:
-    name: rocq-mathcomp-ssreflect
-    version: '{ (>= "2.5.0") }'
+    name: coq-mathcomp-ssreflect
+    version: '{ (>= "2.6.0") | (= "dev") }'
   description: |-
     [MathComp ssreflect](https://math-comp.github.io)
 - opam:
-    name: rocq-mathcomp-fingroup
-    version: '{ (>= "2.5.0") }'
+    name: coq-mathcomp-fingroup
+    version: '{ (>= "2.6.0") | (= "dev") }'
   description: |-
     [MathComp fingroup](https://math-comp.github.io)
 - opam:
-    name: rocq-mathcomp-algebra
-    version: '{ (>= "2.5.0") }'
+    name: coq-mathcomp-algebra
+    version: '{ (>= "2.6.0") | (= "dev") }'
   description: |-
     [MathComp algebra](https://math-comp.github.io)
 - opam:
-    name: rocq-mathcomp-solvable
-    version: '{ (>= "2.5.0") }'
+    name: coq-mathcomp-solvable
+    version: '{ (>= "2.6.0") | (= "dev") }'
   description: |-
     [MathComp solvable](https://math-comp.github.io)
 - opam:
-    name: rocq-mathcomp-field
-    version: '{ (>= "2.5.0") }'
+    name: coq-mathcomp-field
+    version: '{ (>= "2.6.0") | (= "dev") }'
   description: |-
     [MathComp field](https://math-comp.github.io)
 - opam:
-    name: rocq-mathcomp-analysis
-    version: '{ (>= "1.15.0") }'
+    name: coq-mathcomp-analysis
+    version: '{ (>= "1.17.0") | (= "dev") }'
   description: |-
     [MathComp analysis](https://github.com/math-comp/analysis)
 - opam:
     name: coq-mathcomp-real-closed
-    version: '{ (>= "2.0.0") }'
+    version: '{ (>= "2.0.5") | (= "dev") }'
   description: |-
     [MathComp real closed](https://github.com/math-comp/real-closed)
 - opam:
     name: coq-mathcomp-algebra-tactics
-    version: '{ (>= "1.2.4") }'
+    version: '{ (>= "1.2.4") | (= "dev") }'
   description: |-
     [MathComp algebra tactics](https://github.com/math-comp/algebra-tactics)
 

--- a/meta.yml
+++ b/meta.yml
@@ -35,7 +35,6 @@ supported_rocq_versions:
 
 tested_rocq_opam_versions:
 - version: 'rocq-prover-9.1'
-  repo: 'mathcomp/mathcomp'
 
 dependencies:
 - opam:

--- a/octonion.v
+++ b/octonion.v
@@ -624,7 +624,7 @@ Proof.
 case: a b => [a0 a1] [b0 b1]; congr mkOct => /=; last first.
   rewrite !(linearB, linearD, mulrBl, mulrDl, mulrBr, mulrDr) /= conjqI.
 rewrite !(mulNr, opprK) [-(a1 * _) - _]addrC {1}subrK.
-rewrite [_ - b1 * _]addrC subrK; first by rewrite addrC.
+rewrite [_ - b1 * _]addrC subrK; last by rewrite addrC.
 rewrite !(linearN, linearB, mulrBl, mulrDl, mulrBr, mulrDr) /=
           !conjqM /= !conjqI opprK.
 rewrite [b0 * _ + _]addrC addrK [_ * a0 + _]addrC addrK.
@@ -855,7 +855,7 @@ Lemma conjoE (a : oct R) :
                        + 1%:or *o a *o 1%:or
                        + `ir *o a *o `ir + `jr *o a *o `jr + `kr *o a *o `kr).
 Proof.
-rewrite (_  : - (1/6%:R) = ((1/3%:R) * -(1/2%:R))); last first.
+rewrite (_  : - (1/6%:R) = ((1/3%:R) * -(1/2%:R))).
   by rewrite mulrN !mulrA mulr1 -mulrA -invfM -natrM.
 rewrite -3!addrA scalerDr.
 apply/eqP; rewrite eq_oct; apply/andP; split; apply/eqP.
@@ -1001,8 +1001,8 @@ Qed.
 Lemma normoV (a : oct R) : normo (invo a) = normo a / sqro a.
 Proof.
 rewrite /invo normoZ normoc ger0_norm.
-  by rewrite mulrC mul1r.
-by rewrite mul1r invr_ge0 sqro_ge0.
+  by rewrite mul1r invr_ge0 sqro_ge0.
+by rewrite mulrC mul1r.
 Qed.
 
 End octonion1.

--- a/octonion.v
+++ b/octonion.v
@@ -1,6 +1,6 @@
 (* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From HB Require Import structures.
-From mathcomp Require Import all_boot all_order ssralg ssrint ssrnum rat poly.
+From mathcomp Require Import boot order ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import realalg complex fingroup perm.
 From mathcomp Require Import sesquilinear.

--- a/quaternion.v
+++ b/quaternion.v
@@ -3,7 +3,7 @@ From HB Require Import structures.
 From mathcomp Require Import all_boot order ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import sesquilinear.
-From mathcomp Require Import ring.
+From mathcomp Require Import ring_tactic field_tactic.
 From mathcomp Require Import realalg complex fingroup perm.
 From mathcomp Require Import interval reals trigo.
 Require Import ssr_ext euclidean vec_angle frame rot.
@@ -543,7 +543,7 @@ rewrite scaler0 add0r double_crossmul dotmulvv enormeE expr1n scale1r.
 rewrite [_ *v 'e_2%:R](@lieC _ (vec3 R)) /= ['e_2%:R *v _]linearD /=.
 rewrite ['e_2%:R *v (x.1 *: _)]linearZ /= (@liexx _ (vec3 R)).
 rewrite scaler0 add0r double_crossmul dotmulvv enormeE expr1n scale1r.
-rewrite [X in _ = - _ *: X](_ : _ = 2%:R *:x.2).
+rewrite [X in _ = - _ *: X](_ : _ = 2%:R *:x.2); last first.
   by rewrite scalerA mulNr div1r mulVr ?unitfE ?pnatr_eq0 // scaleN1r.
 rewrite !opprB (addrCA _ x.2).
 rewrite (addrA x.2 x.2) [in RHS]scaler_nat -[RHS]addr0.
@@ -633,8 +633,7 @@ Proof. by rewrite /normq /sqrq /= enormN. Qed.
 
 Lemma normqE x : (normq x ^+ 2)%:q = x^*q * x.
 Proof.
-rewrite -normqc /normq sqr_sqrtr; last by rewrite /sqrq addr_ge0 // sqr_ge0.
-by rewrite -conjqP conjqI.
+by rewrite -normqc /normq sqr_sqrtr /sqrq ?addr_ge0 ?sqr_ge0// -conjqP conjqI.
 Qed.
 
 Lemma normq_ge0 x : 0 <= normq x.
@@ -650,7 +649,7 @@ Qed.
 
 Lemma normqM x y : normq (x * y) = normq x * normq y.
 Proof.
-apply/eqP; rewrite -(@eqrXn2 _ 2) // ?normq_ge0 //; last first.
+apply/eqP; rewrite -(@eqrXn2 _ 2) // ?normq_ge0 //.
   by rewrite mulr_ge0 // normq_ge0.
 rewrite -quat_scalarE normqE conjqM -mulrA (mulrA x^*q) -normqE.
 rewrite quat_algE mulr_algl -scalerAr exprMn quat_realM.
@@ -665,7 +664,7 @@ Qed.
 
 Lemma normqV x : normq (x^-1) = normq x / sqrq x.
 Proof.
-rewrite invqE /invq normqZ ger0_norm; last first.
+rewrite invqE /invq normqZ ger0_norm.
   by rewrite divr_ge0 // ?ler01 // /sqrq addr_ge0 // sqr_ge0.
 by rewrite normqc mulrC mul1r.
 Qed.
@@ -679,7 +678,7 @@ Definition normalizeq x : quat R := 1 / normq x *: x.
 
 Lemma normalizeq1 x : x != 0 -> normq (normalizeq x) = 1.
 Proof.
-move=> x0; rewrite /normalizeq normqZ normrM normr1 mul1r normrV; last first.
+move=> x0; rewrite /normalizeq normqZ normrM normr1 mul1r normrV.
   by rewrite unitfE normq_eq0.
 by rewrite ger0_norm ?normq_ge0 // mulVr // unitfE normq_eq0.
 Qed.
@@ -707,7 +706,7 @@ apply: le_trans (_ : Num.sqrt (\sum_(i < 4) (`|X i| + `|Y i|) ^+ 2) <= _).
   rewrite !sqr_sqrtr; try by apply: sumr_ge0 => i _; apply: sqr_ge0.
   apply: ler_sum => i _; rewrite !sqrrD.
   by rewrite !sqr_normE; do ! apply: lerD => //.
-rewrite -ler_sqr ?nnegrE; last 2 first.
+rewrite -ler_sqr ?nnegrE.
 - by apply: sqrtr_ge0.
 - by apply: addr_ge0; apply: sqrtr_ge0.
 rewrite [in X in _ <= X]sqrrD !sqr_sqrtr;
@@ -719,10 +718,10 @@ under [X in _ <= _ + _ X * _ *+2  + _]eq_bigr do rewrite -sqr_normE.
 under [X in _ <= _ + _ + X]eq_bigr do rewrite -sqr_normE.
 under [X in _ <= _ + _ * _ X *+2  + _]eq_bigr do rewrite -sqr_normE.
 do 2 (apply: lerD => //); rewrite lerMn2r /=.
-rewrite -ler_sqr ?nnegrE; last 2 first.
+rewrite -ler_sqr ?nnegrE.
 - by apply: sumr_ge0 => i _; apply: mulr_ge0; apply: normr_ge0.
 - by apply: mulr_ge0; apply: sqrtr_ge0.
-rewrite exprMn !sqr_sqrtr; last 2 first.
+rewrite exprMn !sqr_sqrtr.
 - by apply: sumr_ge0=> i _; apply: sqr_ge0.
 - by apply: sumr_ge0=> i _; apply: sqr_ge0.
 (* This is Cauchy Schwartz *)
@@ -1005,12 +1004,12 @@ do 2 rewrite (addrCA _ (_ *: v)); congr (_ + _).
 do 2 rewrite (addrCA _ (_ *: x.2 *+ 2)).
 rewrite dotmulDr scalerDl mulrnDl -addrA addrCA; congr (_ + _).
 rewrite dotmulvZ -scalerA scalerMnr.
-rewrite -(scalerMnr k); congr (_ + _).
-rewrite scalerMnr scalerA (mulrC _ x.1) -scalerA.
-rewrite scalerMnr -scalerDr; congr (_ *: _).
-rewrite -scalerMnr -mulrnDl.
-congr (_ *+ _).
-by rewrite linearD/= linearZ/=.
+  by rewrite !scalerMnr.
+congr (_ + _).
+rewrite scalerMnr.
+rewrite 2!(scalerMnr x.1) scalerA mulrC -scalerA -(scalerMnr k) -scalerDr -mulrnDl.
+congr (_ *: (_ *+ _)).
+by rewrite linearD /= linearZ /=.
 Qed.
 
 HB.instance Definition _ x := @GRing.isLinear.Build _ _ _ _ _ (quat_rot_is_linear x).
@@ -1419,7 +1418,7 @@ Proof. by rewrite dnumE' eqxx. Qed.
 Lemma dnum_nat n : n%:R \is dnum.
 Proof.
 elim: n => [|n IH]; first by rewrite dnum0.
-by rewrite -add1n natrD dnumD; [by []|exact: dnum1|exact: IH].
+by rewrite -add1n natrD dnumD; [exact: dnum1|exact: IH|by []].
 Qed.
 
 Lemma dnumM x y : x \is dnum -> y \is dnum -> x * y \is dnum.

--- a/quaternion.v
+++ b/quaternion.v
@@ -1,6 +1,6 @@
 (* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From HB Require Import structures.
-From mathcomp Require Import all_boot order ssralg ssrint ssrnum rat poly.
+From mathcomp Require Import boot order ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import sesquilinear.
 From mathcomp Require Import ring_tactic field_tactic.

--- a/quaternion.v
+++ b/quaternion.v
@@ -95,7 +95,7 @@ Local Open Scope ring_scope.
 Import Order.TTheory GRing.Theory Num.Def Num.Theory.
 
 Section quaternion0.
-Variable R : pzRingType.
+Context (R : pzRingType).
 
 Record quat := mkQuat {quatl : R ; quatr : 'rV[R]_3 }.
 Implicit Types x y : quat.
@@ -112,7 +112,7 @@ Local Notation "x '_k'" := ((x.2)``_(2%:R : 'I_3)).
 Coercion pair_of_quat x := let: mkQuat x1 x2 := x in (x1, x2).
 Let quat_of_pair (a : R * 'rV[R]_3) := let: (a1, a2) := a in mkQuat a1 a2.
 
-Lemma quat_of_pairK : cancel pair_of_quat quat_of_pair.
+Let quat_of_pairK : cancel pair_of_quat quat_of_pair.
 Proof. by case. Qed.
 
 HB.instance Definition _ := Equality.copy quat (can_type quat_of_pairK).
@@ -128,19 +128,19 @@ Qed.
 Definition addq x y := mkQuat (x.1 + y.1) (x.2 + y.2).
 Arguments addq : simpl never.
 
-Lemma addqC : commutative addq.
+Let addqC : commutative addq.
 Proof. move=> *; congr mkQuat; by rewrite addrC. Qed.
 
-Lemma addqA : associative addq.
+Let addqA : associative addq.
 Proof. move=> *; congr mkQuat; by rewrite addrA. Qed.
 
-Lemma add0q : left_id 0%:q addq.
+Let add0q : left_id 0%:q addq.
 Proof. case=> *; by rewrite /addq /= 2!add0r. Qed.
 
 Definition oppq x := mkQuat (- x.1) (- x.2).
 Arguments oppq : simpl never.
 
-Lemma addNq : left_inverse 0%:q oppq addq.
+Let addNq : left_inverse 0%:q oppq addq.
 Proof. move=> *; congr mkQuat; by rewrite addNr. Qed.
 
 HB.instance Definition _ := @GRing.isZmodule.Build quat _ _ _ addqA addqC add0q addNq.

--- a/rigid.v
+++ b/rigid.v
@@ -237,8 +237,8 @@ rewrite /relative_displacement mulmxBr mulmx1 opprB.
 rewrite -img_vec_iso.
 rewrite /displacement.
 rewrite addrACA.
-rewrite (addrCA (f a)) subrr addr0.
-by rewrite (addrCA _ a) addrA subrr sub0r.
+rewrite (addrCA (f a)) (subrr (f a)) addr0.
+by rewrite (addrCA _ a) (addrA a) (subrr a) sub0r.
 Qed.
 
 End isometry_3_properties.
@@ -366,8 +366,7 @@ have -> : iso_sgn f = noframe_sgn f'.
   have -> : f'~k = f`* u3p by rewrite rowframeE rowK.
   by rewrite dmap_iso_sgnP /= !rowframeE !rowE !mulmx1 vecjk dote2 mulr1.
 have : (f`* u) *v (f`* v) = noframe_sgn f' *: (f`* (u *v v)) :> vector.
-  rewrite /=.
-  rewrite (@crossmul_noframe_sgn _ f' (f`* u) u1 u2 u3 (f`* v) v1 v2 v3) //; last 2 first.
+  rewrite /= (@crossmul_noframe_sgn _ f' (f`* u) u1 u2 u3 (f`* v) v1 v2 v3) //.
     move: Ku.
     by rewrite !rowframeE /= !rowK /=.
     move: Kv.
@@ -386,11 +385,11 @@ have : (f`* u) *v (f`* v) = noframe_sgn f' *: (f`* (u *v v)) :> vector.
   rewrite linearD [in RHS]/=.
   rewrite [in X in _ = - (_ *: X) *m _ + _ + _]linearD.
   rewrite [in RHS]/=.
-  rewrite (_ : 'e_0 *v (u1 *: _) = 0); last by rewrite linearZ /= (@liexx _ (vec3 T)) scaler0.
-  rewrite (_ : 'e_0 *v (u2 *: _) = u2 *: 'e_2%:R); last first.
+  rewrite (_ : 'e_0 *v (u1 *: _) = 0); first by rewrite linearZ /= (@liexx _ (vec3 T)) scaler0.
+  rewrite (_ : 'e_0 *v (u2 *: _) = u2 *: 'e_2%:R).
     rewrite linearZ /=.
     by rewrite vecij.
-  rewrite (_ : 'e_0 *v (u3 *: _) = - u3 *: 'e_1); last first.
+  rewrite (_ : 'e_0 *v (u3 *: _) = - u3 *: 'e_1).
     rewrite linearZ /=.
     rewrite vecik.
     by rewrite scalerN scaleNr.
@@ -403,11 +402,11 @@ have : (f`* u) *v (f`* v) = noframe_sgn f' *: (f`* (u *v v)) :> vector.
   rewrite opprD.
   rewrite [in X in _ = _ + X + _]linearD [in X in _ = _ + X + _]/=.
   rewrite scaleNr scalerN opprK.
-  rewrite (_ : _ *v _ = - u1 *: 'e_2%:R); last first.
+  rewrite (_ : _ *v _ = - u1 *: 'e_2%:R).
     by rewrite linearZ /= (@lieC _ (vec3 T)) /= vecij scalerN scaleNr.
-  rewrite (_ : _ *v _ = 0); last by rewrite linearZ /= (@liexx _ (vec3 T)) scaler0.
+  rewrite (_ : _ *v _ = 0); first by rewrite linearZ /= (@liexx _ (vec3 T)) scaler0.
   rewrite addr0.
-  rewrite (_ : _ *v _ = u3 *: 'e_0); last by rewrite linearZ /= vecjk.
+  rewrite (_ : _ *v _ = u3 *: 'e_0); first by rewrite linearZ /= vecjk.
   rewrite scaleNr opprK mulmxBl.
   rewrite -![in RHS]scalemxAl.
   rewrite scalerDr scalerN.
@@ -415,20 +414,22 @@ have : (f`* u) *v (f`* v) = noframe_sgn f' *: (f`* (u *v v)) :> vector.
   rewrite opprD.
   rewrite [in X in _ = _ + _ + X]linearD [in X in _ = _ + _ + X]/=.
   rewrite opprD.
-  rewrite (_ : _ *v _ = u1 *: 'e_1); last first.
+  rewrite (_ : _ *v _ = u1 *: 'e_1).
     by rewrite linearZ /= (@lieC _ (vec3 T)) /= vecik opprK.
-  rewrite (_ : _ *v _ = - u2 *: 'e_0); last first.
+  rewrite (_ : _ *v _ = - u2 *: 'e_0).
     by rewrite linearZ /= (@lieC _ (vec3 T)) /= vecjk scalerN scaleNr.
-  rewrite (_ : _ *v _ = 0); last by rewrite linearZ /= (@liexx _ (vec3 T)) scaler0.
+  rewrite (_ : _ *v _ = 0); first by rewrite linearZ /= (@liexx _ (vec3 T)) scaler0.
   rewrite subr0 scaleNr opprK mulmxDl mulNmx.
   rewrite -![in RHS]scalemxAl.
   rewrite -![in RHS]addrA [in RHS]addrC -[in RHS]addrA [in RHS]addrCA -[in RHS]addrA [in RHS]addrC.
-  rewrite ![in RHS]addrA -[in RHS]addrA.
+  rewrite ![in RHS]addrA.
+  rewrite -(addrA _ _ (v2 *: (u1 *: ('e_2%:R *m ortho_of_iso f)))).
   congr (_ + _); last first.
     rewrite !scalerA -scaleNr -scalerDl addrC mulrC (mulrC u1).
     by rewrite /e3 /dmap /u3p rowframeE rowE mulmx1.
   rewrite scalerDr.
-  rewrite -![in RHS]addrA [in RHS]addrCA [in RHS]addrC ![in RHS]addrA -addrA; congr (_ + _).
+  rewrite -![in RHS]addrA [in RHS]addrCA [in RHS]addrC ![in RHS]addrA.
+  rewrite -(addrA _ _ (v3 *: - (u1 *: ('e_1 *m ortho_of_iso f)))); congr (_ + _).
     rewrite /e1 /dmap /u1p.
     rewrite rowframeE rowE mulmx1.
     by rewrite !scalerA -scaleNr -scalerDl addrC mulrC (mulrC u2).
@@ -461,7 +462,7 @@ rewrite K scaleN1r => /eqP; rewrite eqmxNxx.
 move: (mulmxr_crossmulr u v (ortho_of_iso_is_O f)).
 rewrite -/(iso_sgn f) K scaleN1r => /esym/eqP.
 rewrite eqr_oppLR => /eqP ->.
-rewrite oppr_eq0 mul_mx_rowfree_eq0; last first.
+rewrite oppr_eq0 mul_mx_rowfree_eq0.
   apply/row_freeP.
   exists (ortho_of_iso f)^T.
   apply/eqP; by rewrite -orthogonalE ortho_of_iso_is_O.
@@ -717,7 +718,7 @@ Lemma homV (T : comUnitRingType) M : M \is 'SE3[T] -> M * inv_hom M = 1.
 Proof.
 move=> HM.
 rewrite (SE3E HM) /= /inv_hom rot_of_hom_hom trans_of_hom_hom.
-rewrite homM -rotation_inv ?rot_of_hom_is_SO // divrr; last first.
+rewrite homM -rotation_inv ?rot_of_hom_is_SO // divrr.
   by apply/orthogonal_unit/rotation_sub/rot_of_hom_is_SO.
 by rewrite mulNmx subrr hom10.
 Qed.
@@ -726,7 +727,7 @@ Lemma Vhom (T : fieldType) M : M \is 'SE3[T] -> inv_hom M * M = 1.
 Proof.
 move=> HM.
 rewrite (SE3E HM) /= /inv_hom rot_of_hom_hom trans_of_hom_hom.
-rewrite homM -rotation_inv ?rot_of_hom_is_SO // mulVr; last first.
+rewrite homM -rotation_inv ?rot_of_hom_is_SO // mulVr.
   by apply/orthogonal_unit/rotation_sub/rot_of_hom_is_SO.
 rewrite -mulmxA mulVmx ?mulmx1 1?addrC ?subrr ?hom10 // .
 by rewrite unitmxE unitfE rotation_det ?oner_eq0 // rot_of_hom_is_SO.
@@ -846,7 +847,7 @@ rewrite /Adjoint -rot_of_homM // trans_of_homM // spinD.
 set a := rot_of_hom (_ * _) * _. set b := rot_of_hom (_ * _) * _.
 suff : a = b by move=> ->.
 rewrite {}/a {}/b; congr (_ * _).
-rewrite spin_similarity; last by rewrite rot_of_hom_is_SO.
+rewrite spin_similarity; first by rewrite rot_of_hom_is_SO.
 by rewrite -/t1 -/t2 -/r2 addrC.
 Qed.
 
@@ -922,7 +923,7 @@ Definition inv (m : t) : t := insubd one (- trans m *m (rot m)^T, (rot m)^T).
 
 Lemma inv'V m : hom_of m *m inv' m = 1.
 Proof.
-rewrite /inv' mulmxE homM -rotation_inv // divrr; last first.
+rewrite /inv' mulmxE homM -rotation_inv // divrr.
   exact/orthogonal_unit/rotation_sub.
 by rewrite mulNmx subrr hom10.
 Qed.
@@ -930,7 +931,7 @@ Qed.
 Lemma invV m : hom_of m *m hom_of (inv m) = 1.
 Proof.
 case: m => -[t r] /= Hr.
-rewrite /hom_of /inv /rot /trans /= insubdK; first exact: (inv'V (mk (t, r) Hr)).
+rewrite /hom_of /inv /rot /trans /= insubdK; last exact: (inv'V (mk (t, r) Hr)).
 by rewrite -rotationV in Hr.
 Qed.
 

--- a/rigid.v
+++ b/rigid.v
@@ -1,6 +1,6 @@
 (* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From HB Require Import structures.
-From mathcomp Require Import all_boot ssralg ssrint ssrnum rat poly.
+From mathcomp Require Import boot ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import realalg complex finset fingroup perm.
 From mathcomp Require Import interval reals trigo.

--- a/robot-rocq.opam
+++ b/robot-rocq.opam
@@ -19,16 +19,16 @@ Mathematical Components library."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" 
-  "rocq-hierarchy-builder" { (>= "1.10.0") }
-  "rocq-mathcomp-ssreflect" { (>= "2.5.0") }
-  "rocq-mathcomp-fingroup" { (>= "2.5.0") }
-  "rocq-mathcomp-algebra" { (>= "2.5.0") }
-  "rocq-mathcomp-solvable" { (>= "2.5.0") }
-  "rocq-mathcomp-field" { (>= "2.5.0") }
-  "rocq-mathcomp-analysis" { (>= "1.15.0") }
-  "coq-mathcomp-real-closed" { (>= "2.0.0") }
-  "coq-mathcomp-algebra-tactics" { (>= "1.2.4") }
+  "coq" { (>= "9.1" & < "9.4~") }
+  "rocq-hierarchy-builder" { (>= "1.10.0") | (= "dev") }
+  "coq-mathcomp-ssreflect" { (>= "2.6.0") | (= "dev") }
+  "coq-mathcomp-fingroup" { (>= "2.6.0") | (= "dev") }
+  "coq-mathcomp-algebra" { (>= "2.6.0") | (= "dev") }
+  "coq-mathcomp-solvable" { (>= "2.6.0") | (= "dev") }
+  "coq-mathcomp-field" { (>= "2.6.0") | (= "dev") }
+  "coq-mathcomp-analysis" { (>= "1.17.0") | (= "dev") }
+  "coq-mathcomp-real-closed" { (>= "2.0.5") | (= "dev") }
+  "coq-mathcomp-algebra-tactics" { (>= "1.2.4") | (= "dev") }
 ]
 
 tags: [

--- a/robot-rocq.opam
+++ b/robot-rocq.opam
@@ -20,14 +20,14 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" 
-  "rocq-hierarchy-builder" { (>= "1.10.0") | (= "dev") }
-  "rocq-mathcomp-ssreflect" { (>= "2.6.0") | (= "dev") }
-  "rocq-mathcomp-fingroup" { (>= "2.6.0") | (= "dev") }
-  "rocq-mathcomp-algebra" { (>= "2.6.0") | (= "dev") }
-  "rocq-mathcomp-solvable" { (>= "2.6.0") | (= "dev") }
-  "rocq-mathcomp-field" { (>= "2.6.0") | (= "dev") }
-  "rocq-mathcomp-analysis" { (>= "1.17.0") | (= "dev") }
-  "rocq-mathcomp-real-closed" { (>= "2.0.6") | (= "dev") }
+  "rocq-hierarchy-builder" { (>= "1.10.0") }
+  "rocq-mathcomp-ssreflect" { (>= "2.6.0") }
+  "rocq-mathcomp-fingroup" { (>= "2.6.0") }
+  "rocq-mathcomp-algebra" { (>= "2.6.0") }
+  "rocq-mathcomp-solvable" { (>= "2.6.0") }
+  "rocq-mathcomp-field" { (>= "2.6.0") }
+  "rocq-mathcomp-analysis" { (>= "1.17.0") }
+  "rocq-mathcomp-real-closed" { (>= "2.0.6") }
 ]
 
 tags: [

--- a/robot-rocq.opam
+++ b/robot-rocq.opam
@@ -19,16 +19,15 @@ Mathematical Components library."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" { (>= "9.1" & < "9.4~") }
+  "coq" 
   "rocq-hierarchy-builder" { (>= "1.10.0") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "2.6.0") | (= "dev") }
-  "coq-mathcomp-fingroup" { (>= "2.6.0") | (= "dev") }
-  "coq-mathcomp-algebra" { (>= "2.6.0") | (= "dev") }
-  "coq-mathcomp-solvable" { (>= "2.6.0") | (= "dev") }
-  "coq-mathcomp-field" { (>= "2.6.0") | (= "dev") }
-  "coq-mathcomp-analysis" { (>= "1.17.0") | (= "dev") }
-  "coq-mathcomp-real-closed" { (>= "2.0.5") | (= "dev") }
-  "coq-mathcomp-algebra-tactics" { (>= "1.2.4") | (= "dev") }
+  "rocq-mathcomp-ssreflect" { (>= "2.6.0") | (= "dev") }
+  "rocq-mathcomp-fingroup" { (>= "2.6.0") | (= "dev") }
+  "rocq-mathcomp-algebra" { (>= "2.6.0") | (= "dev") }
+  "rocq-mathcomp-solvable" { (>= "2.6.0") | (= "dev") }
+  "rocq-mathcomp-field" { (>= "2.6.0") | (= "dev") }
+  "rocq-mathcomp-analysis" { (>= "1.17.0") | (= "dev") }
+  "rocq-mathcomp-real-closed" { (>= "2.0.6") | (= "dev") }
 ]
 
 tags: [

--- a/rot.v
+++ b/rot.v
@@ -141,12 +141,12 @@ Proof.
 move=> abpi.
 have -> : sin b = cos a.
   rewrite -[b](subrK a) sinD abpi mul1r [cos (_ - _)]sin1cos0.
-    by rewrite mul0r addr0.
-  by rewrite abpi normr1.
+    by rewrite abpi normr1.
+  by rewrite mul0r addr0.
 have -> : cos b = - sin a.
   rewrite -[b](subrK a) cosD abpi mul1r [cos (_ - _)]sin1cos0.
-    by rewrite mul0r sub0r.
-  by rewrite abpi normr1.
+    by rewrite abpi normr1.
+  by rewrite mul0r sub0r.
 move=> ->; exists (norm_angle a); first by apply: norm_angle_bound.
 by rewrite /RO cos_norm_angle sin_norm_angle.
 Qed.
@@ -179,12 +179,12 @@ Proof.
 move=> abpi.
 have -> : sin b = - cos a.
   rewrite -[a](subrK b) cosD abpi mul1r [cos (_ - _)]sin1cos0.
-    by rewrite mul0r sub0r opprK.
-  by rewrite abpi normr1.
+    by rewrite abpi normr1.
+  by rewrite mul0r sub0r opprK.
 have -> : cos b = sin a.
   rewrite -[a](subrK b) sinD abpi mul1r [cos (_ - _)]sin1cos0.
-    by rewrite mul0r addr0.
-  by rewrite abpi normr1.
+    by rewrite abpi normr1.
+  by rewrite mul0r addr0.
 move=> ->; exists (norm_angle a); first exact: norm_angle_bound.
 by rewrite /RO' cos_norm_angle sin_norm_angle.
 Qed.
@@ -244,10 +244,10 @@ Qed.
 
 Lemma Rx_RO a : Rx a = block_mx (1 : 'M_1) 0 0 (RO a).
 Proof.
-rewrite -(@submxK _ 1 2 1 2 (Rx a)) (_ : ulsubmx _ = 1); last first.
+rewrite -(@submxK _ 1 2 1 2 (Rx a)) (_ : ulsubmx _ = 1).
   apply/rowP => i; by rewrite (ord1 i) !mxE /=.
-rewrite (_ : ursubmx _ = 0); last by apply/rowP => i; rewrite !mxE.
-rewrite (_ : dlsubmx _ = 0); last first.
+rewrite (_ : ursubmx _ = 0); first by apply/rowP => i; rewrite !mxE.
+rewrite (_ : dlsubmx _ = 0).
   apply/colP => i; rewrite !mxE /=.
   case: ifPn; [by rewrite !mxE | by case: ifPn; rewrite !mxE].
 rewrite (_ : drsubmx _ = RO a) //; by apply/matrix2P; rewrite !mxE /= !eqxx.
@@ -272,10 +272,10 @@ Definition Rx' a := col_mx3
 
 Lemma Rx'_RO a : Rx' a = block_mx (1 : 'M_1) 0 0 (RO' a).
 Proof.
-rewrite -(@submxK _ 1 2 1 2 (Rx' a)) (_ : ulsubmx _ = 1); last first.
+rewrite -(@submxK _ 1 2 1 2 (Rx' a)) (_ : ulsubmx _ = 1).
   apply/rowP => i; by rewrite (ord1 i) !mxE /=.
-rewrite (_ : ursubmx _ = 0); last by apply/rowP => i; rewrite !mxE.
-rewrite (_ : dlsubmx _ = 0); last first.
+rewrite (_ : ursubmx _ = 0); first by apply/rowP => i; rewrite !mxE.
+rewrite (_ : dlsubmx _ = 0).
   apply/colP => i; rewrite !mxE /=.
   case: ifPn; first by rewrite !mxE.
   by case: ifPn; rewrite !mxE.
@@ -310,10 +310,10 @@ Definition Rz a := col_mx3
 
 Lemma Rz_RO a : Rz a = block_mx (RO a) 0 0 (1 : 'M_1).
 Proof.
-rewrite -(@submxK _ 2 1 2 1 (Rz a)) (_ : drsubmx _ = 1); last first.
+rewrite -(@submxK _ 2 1 2 1 (Rz a)) (_ : drsubmx _ = 1).
   apply/rowP => i; by rewrite (ord1 i) !mxE.
-rewrite (_ : ulsubmx _ = RO a); last by apply/matrix2P; rewrite !mxE !eqxx.
-rewrite (_ : ursubmx _ = 0); last first.
+rewrite (_ : ulsubmx _ = RO a); first by apply/matrix2P; rewrite !mxE !eqxx.
+rewrite (_ : ursubmx _ = 0).
   apply/colP => i; case/boolP : (i == 0) => [|/ifnot01P]/eqP->; by rewrite !mxE.
 rewrite (_ : dlsubmx _ = 0) //; apply/rowP => i; rewrite !mxE /=.
 by case/boolP : (i == 0) => [|/ifnot01P]/eqP->.
@@ -497,11 +497,11 @@ rewrite (invariant_colinear u0 H1) ?colinear_frame0 //.
 move/(_ erefl erefl erefl) => fRx.
 have HfRx : M^-1 = (col_mx3 (Base.frame u)|,0 (Base.frame u)|,1 (Base.frame u)|,2%:R)^T *m
    (Rx (- a))^-1 *m col_mx3 (Base.frame u)|,0 (Base.frame u)|,1 (Base.frame u)|,2%:R.
-  rewrite fRx invrM /=; last 2 first.
+  rewrite fRx invrM /=.
     rewrite unitrMr orthogonal_unit // ?(rotation_sub (Rx_is_SO _)) //.
     by rewrite rotation_inv ?Base.is_SO // rotation_sub // rotationV Base.is_SO.
     by rewrite orthogonal_unit // rotation_sub // Base.is_SO.
-  rewrite invrM; last 2 first.
+  rewrite invrM.
     rewrite rotation_inv ?Base.is_SO // orthogonal_unit // rotation_sub //.
     by rewrite rotationV // Base.is_SO.
     by rewrite orthogonal_unit // ?(rotation_sub (Rx_is_SO _)).
@@ -509,16 +509,16 @@ have HfRx : M^-1 = (col_mx3 (Base.frame u)|,0 (Base.frame u)|,1 (Base.frame u)|,
 apply/isRotP; split => /=.
 - by rewrite -{1}H1 -mulmxA mulmxV // mulmx1.
 - rewrite HfRx !mulmxA.
-  rewrite (_ : (Base.frame u)|,1 *m _ = 'e_1); last first.
+  rewrite (_ : (Base.frame u)|,1 *m _ = 'e_1).
     by rewrite mul_tr_col_mx3 dotmulC dotmulvv normj // expr1n idotj // jdotk // e1row.
-  rewrite (_ : 'e_1 *m _ = row3 0 (cos (- a)) (sin a)); last first.
+  rewrite (_ : 'e_1 *m _ = row3 0 (cos (- a)) (sin a)).
     rewrite (rotation_inv (Rx_is_SO (- a))) /Rx mul_tr_col_mx3.
     rewrite dote2 /= 2!dotmulE 2!sum3E !mxE /= cosN sinN opprK. by Simp.r.
   by rewrite mulmx_row3_col3 scale0r add0r cosN.
 - rewrite HfRx !mulmxA.
-  rewrite (_ : (Base.frame u)|,2%:R *m _ = 'e_2%:R); last first.
+  rewrite (_ : (Base.frame u)|,2%:R *m _ = 'e_2%:R).
     by rewrite mul_tr_col_mx3 dotmulC idotk // dotmulC jdotk // dotmulvv normk // expr1n e2row.
-  rewrite (_ : 'e_2%:R *m _ = row3 0 (- sin a) (cos a)); last first.
+  rewrite (_ : 'e_2%:R *m _ = row3 0 (- sin a) (cos a)).
     rewrite (rotation_inv (Rx_is_SO (- a))) /Rx mul_tr_col_mx3.
     rewrite dote2 /= 2!dotmulE 2!sum3E !mxE /= cosN sinN opprK. by Simp.r.
   by rewrite mulmx_row3_col3 scale0r add0r.
@@ -662,7 +662,7 @@ rewrite addrC ![in LHS]addrA addrK.
 rewrite -![in LHS]addrA addrC scalerBl scale1r scalerBr opprB scalerA -![in LHS]addrA.
 rewrite [in RHS]addrA [in RHS]addrC; congr (_ + _).
 rewrite addrCA ![in LHS]addrA subrK -scalerCA -2!scalerAl -exprD.
-rewrite (_ : M ^+ 4 = - M ^+ 2); last by rewrite exprS cube_u mulrN -expr2.
+rewrite (_ : M ^+ 4 = - M ^+ 2); first by rewrite exprS cube_u mulrN -expr2.
 rewrite 2!scalerN scalerA.
 rewrite addrC -scaleNr -2!scalerDl -scalerBl; congr (_ *: _).
 rewrite -!addrA; congr (_ + _).
@@ -675,11 +675,11 @@ Lemma inv_emx3 a M : M ^+ 4 = - M ^+ 2 -> `e(a, M) * `e(a, - M) = 1.
 Proof.
 move=> aM.
 case/boolP : (cos a == 1) => [/eqP|] ca; rewrite /emx3.
-  rewrite ca subrr (_ : sin a = 0) ; last by rewrite cos1sin0 // ca normr1.
+  rewrite ca subrr (_ : sin a = 0) ; first by rewrite cos1sin0 // ca normr1.
   by rewrite !scale0r !addr0 mulr1.
 rewrite !mulrDr !mulrDl !mulr1 !mul1r -[RHS]addr0 -!addrA; congr (_ + _).
 rewrite !addrA sqrrN -!addrA (addrCA (_ *: M ^+ 2)) !addrA scalerN subrr add0r.
-rewrite (_ : (1 - _) *: _ * _ = - (sin a *: M * ((1 - cos a) *: M ^+ 2))); last first.
+rewrite (_ : (1 - _) *: _ * _ = - (sin a *: M * ((1 - cos a) *: M ^+ 2))).
   rewrite mulrN; congr (- _).
   by rewrite -2!scalerAr -!scalerAl -exprS -exprSr 2!scalerA mulrC.
 rewrite -!addrA (addrCA (- (sin a *: _ * _))) !addrA subrK.
@@ -733,7 +733,7 @@ Proof.
 move=> w1.
 rewrite 2!mxtraceD !mxtraceZ /= mxtrace1.
 rewrite (trace_anti (spin_is_so w)) mulr0 addr0 mxtrace_sqr_spin w1.
-rewrite (_ : - (_ * _) = - 2%:R); last by rewrite expr1n mulr1.
+rewrite (_ : - (_ * _) = - 2%:R); first by rewrite expr1n mulr1.
 by rewrite mulrDl addrA mul1r -natrB // mulrC mulrN -mulNr opprK.
 Qed.
 
@@ -759,7 +759,7 @@ pose va := 1 - cos a. pose ca := cos a. pose sa := sin a.
 move=> w1; apply/matrix3P/and9P; split; apply/eqP.
 - rewrite 2![in RHS]mxE /= [in LHS]mxE -/sa -/va 3!mxE /= !spinij; Simp.r => /=.
   rewrite sqr_spin' !mxE /=.
-  rewrite (_ : - _ - _ = u``_0 ^+ 2 - 1); last first.
+  rewrite (_ : - _ - _ = u``_0 ^+ 2 - 1).
     rewrite -[in X in _ = _ - X](expr1n _ 2%N) -w1 -dotmulvv dotmulE sum3E -3!expr2.
   by rewrite !opprD !addrA subrr add0r addrC.
 - rewrite mulrBr mulr1 addrCA mulrC; congr (_ + _).
@@ -772,7 +772,7 @@ move=> w1; apply/matrix3P/and9P; split; apply/eqP.
   by rewrite sqr_spin' !mxE /= addrC mulrC (mulrC sa).
 - rewrite 2![in RHS]mxE /= [in LHS]mxE -/sa -/va 3!mxE /= !spinij; Simp.r => /=.
   rewrite sqr_spin' !mxE /=.
-  rewrite (_ : - _ - _ = u``_1 ^+ 2 - 1); last first.
+  rewrite (_ : - _ - _ = u``_1 ^+ 2 - 1).
     rewrite -[in X in _ = _ - X](expr1n _ 2%N) -w1 -dotmulvv dotmulE sum3E -3!expr2.
     by rewrite 2!opprD addrCA addrA subrK addrC.
   rewrite mulrBr mulr1 addrCA mulrC; congr (_ + _).
@@ -785,7 +785,7 @@ move=> w1; apply/matrix3P/and9P; split; apply/eqP.
   by rewrite sqr_spin' !mxE /= addrC mulrC (mulrC sa).
 - rewrite 2![in RHS]mxE /= [in LHS]mxE -/sa -/va 3!mxE /= !spinij; Simp.r => /=.
   rewrite sqr_spin' !mxE /=.
-  rewrite (_ : - _ - _ = u``_2%:R ^+ 2 - 1); last first.
+  rewrite (_ : - _ - _ = u``_2%:R ^+ 2 - 1).
     rewrite -[in X in _ = _ - X](expr1n _ 2%N) -w1 -dotmulvv dotmulE sum3E -3!expr2.
     by rewrite 2!opprD [in RHS]addrC subrK addrC.
   rewrite mulrBr mulr1 addrCA mulrC; congr (_ + _).
@@ -808,7 +808,7 @@ Proof.
 move=> w1.
 move/orthogonal_det/eqP : (eskew_is_O (a / 2%:R) w1).
 rewrite -(@eqrXn2 _ 2) // expr1n sqr_normr expr2 -det_mulmx.
-rewrite mulmxE emx3M; last by rewrite spin3 w1 expr1n scaleN1r.
+rewrite mulmxE emx3M; first by rewrite spin3 w1 expr1n scaleN1r.
 by move/eqP; rewrite -splitr.
 Qed.
 
@@ -837,9 +837,9 @@ rewrite inE eigenvalue_root_char -map_char_poly.
 rewrite /= !inE.
 rewrite  char_poly3 /= trace_eskew // det_eskew //.
 rewrite [`e(_,_) ^+ _]expr2 eskewM // trace_eskew //.
-rewrite (_ : _ - _ = (1 + cos a *+ 2) *+ 2); last first.
+rewrite (_ : _ - _ = (1 + cos a *+ 2) *+ 2).
   rewrite opprD addrA cosD -2!expr2 sin2cos2 opprB addrA -mulr2n mulrDr mulrN1.
-  rewrite opprB addrA -(addrA _ (-1)) (_ : -1 + 2 = 1)//; last first.
+  rewrite opprB addrA -(addrA _ (-1)) (_ : -1 + 2 = 1)//.
     by rewrite addrC; apply/eqP; rewrite subr_eq.
   rewrite -addrA mulr_natl; apply/eqP.
   rewrite eq_sym [eqbRHS]addrC -subr_eq.
@@ -850,7 +850,7 @@ rewrite (_ : _ - _ = (1 + cos a *+ 2) *+ 2); last first.
 rewrite -[(_ + _) *+ _]mulr_natl mulrA divfK ?(eqr_nat _ 2 0) // mul1r.
 rewrite linearB /= map_polyC /= !(linearB, linearD, linearZ) /=.
 rewrite !map_polyXn map_polyX.
-rewrite (_ : _ - _ = ('X - 1) * ('X - (expi a)%:P) * ('X - (expi (-a))%:P)).
+rewrite (_ : _ - _ = ('X - 1) * ('X - (expi a)%:P) * ('X - (expi (-a))%:P)); last first.
   rewrite 2!rootM orbA; congr (_ || _ || _).
   by rewrite root_XsubC.
   by rewrite root_XsubC.
@@ -927,12 +927,12 @@ apply/isRotP; split => /=.
   rewrite dotmul_normalize_enorm scalerA -mulrA divrr ?mulr1 ?unitfE ?enorm_eq0//.
   by rewrite subrK (linearZl_LR _ w)/= (@liexx _ (vec3 T)) 2!scaler0 addr0.
 - rewrite -rodriguesP // /rodrigues dotmulC norm_normalize // expr1n scale1r.
-  rewrite (_ : normalize w = Base.i w) (*NB: lemma?*); last by rewrite /Base.i (negbTE w0).
+  rewrite (_ : normalize w = Base.i w) (*NB: lemma?*); first by rewrite /Base.i (negbTE w0).
   rewrite -Base.jE -Base.kE.
   rewrite Base.idotj // mulr0 scale0r addr0 -Base.icrossj /=  scalerBl scale1r.
   by rewrite opprB addrCA subrr addr0.
 - rewrite -rodriguesP /rodrigues dotmulC norm_normalize // expr1n scale1r.
-  rewrite (_ : normalize w = Base.i w) (*NB: lemma?*); last by rewrite /Base.i (negbTE w0).
+  rewrite (_ : normalize w = Base.i w) (*NB: lemma?*); first by rewrite /Base.i (negbTE w0).
   rewrite -Base.jE -Base.kE.
   rewrite Base.idotk // mulr0 scale0r addr0 scalerBl scale1r opprB addrCA subrr.
   rewrite addr0 addrC; congr (_ + _).
@@ -985,7 +985,7 @@ Lemma normalcomp_double_crossmul p (e : 'rV[T]_3) : `| e |_e = 1 ->
   normalcomp p e *v ((Base.frame e)|,2%:R *v (Base.frame e)|,1) = e *v p.
 Proof.
 move=> u1.
-rewrite 2!rowframeE (@lieC _ (vec3 T) (row _ _)) /= SO_jcrossk; last first.
+rewrite 2!rowframeE (@lieC _ (vec3 T) (row _ _)) /= SO_jcrossk.
   by rewrite -(col_mx3_row (NOFrame.M (Base.frame e))) -!rowframeE Base.is_SO.
 rewrite -rowframeE Base.frame0E ?norm1_neq0 //.
 rewrite normalizeI // {2}(axialnormalcomp p e) linearD /=.
@@ -1000,7 +1000,7 @@ move=> u1 H.
 set v := normalcomp p u.
 move: (orthogonal_expansion (Base.frame u) v).
 set p0 := _|,0. set p1 := _|,1. set p2 := _|,2%:R.
-rewrite (_ : (v *d p0) *: _ = 0) ?add0r; last first.
+rewrite (_ : (v *d p0) *: _ = 0) ?add0r.
   by rewrite /p0 Base.frame0E ?norm1_neq0 // normalizeI // dotmul_normalcomp scale0r.
 move=> ->.
 rewrite mulmxDl -2!scalemxAl.
@@ -1020,10 +1020,10 @@ Lemma isRot_eskew_unit_inv a Q u : `| u |_e = 1 ->
   isRot a u (mx_lin1 Q) -> Q = eskew_unit a u.
 Proof.
 move=> u1 H; apply/eqP/mulmxP => p.
-rewrite (axialnormalcomp (p *m Q) u) axialcomp_mulO; last 2 first.
+rewrite (axialnormalcomp (p *m Q) u) axialcomp_mulO.
   exact/rotation_sub/(isRot_SO (norm1_neq0 u1) H).
   exact: isRot_axis H.
-rewrite normalcomp_mulO //; last 2 first.
+rewrite normalcomp_mulO //.
   exact/rotation_sub/(isRot_SO (norm1_neq0 u1) H).
   exact: isRot_axis H.
 rewrite axialcompE u1 expr1n invr1 scale1r.
@@ -1041,9 +1041,9 @@ Qed.
 
 Lemma axial_skew_unit (e : vector) a : axial (eskew_unit a e) = sin a *: e *+ 2.
 Proof.
-rewrite /eskew_unit 2!axialD (_ : axial _ = 0) ?add0r; last first.
+rewrite /eskew_unit 2!axialD (_ : axial _ = 0) ?add0r.
   apply/eqP; by rewrite -axial_sym mul_tr_vec_sym.
-rewrite (_ : axial _ = 0) ?add0r; last first.
+rewrite (_ : axial _ = 0) ?add0r.
   apply/eqP; rewrite -axial_sym sym_scaler_closed (* TODO: declare the right canonical to be able to use rpredZ *) //.
   by rewrite rpredD // ?sym_cst // rpredN mul_tr_vec_sym.
 rewrite axialZ axialE scalerMnr; congr (_ *: _).
@@ -1080,7 +1080,7 @@ Definition angle M := acos ((\tr M - 1) / 2%:R).
 
 Lemma angle1 : angle 1 = 0.
 Proof.
-rewrite /angle mxtrace1 (_ : 3%:R - 1 = 2%:R); last first.
+rewrite /angle mxtrace1 (_ : 3%:R - 1 = 2%:R).
   by apply/eqP; rewrite subr_eq -(natrD _ 2 1).
 by rewrite divrr ?unitfE ?pnatr_eq0 // acos1.
 Qed.
@@ -1091,7 +1091,7 @@ Lemma anglepi (n : vector) (n1 : `| n |_e = 1) :
   angle (n^T *m n *+ 2 - 1) = pi.
 Proof.
 rewrite /angle mxtraceD linearN /= mxtrace1 mulr2n linearD /=.
-rewrite mxtrace_tr_mul n1 expr1n (_ : _ - 1 = - 2%:R); last first.
+rewrite mxtrace_tr_mul n1 expr1n (_ : _ - 1 = - 2%:R).
   by apply/eqP; rewrite -opprB eqr_opp opprB (_ : 1 + 1 = 2%:R) // -natrB.
 by rewrite -mulr_natl mulNr divrr ?mulr1 ?unitfE ?pnatr_eq0 // acosN1.
 Qed.
@@ -1112,8 +1112,7 @@ Lemma isRot_angleN M u a : u != 0 -> - pi <= a <= 0 ->
   isRot a u (mx_lin1 M) -> a = - angle M.
 Proof.
 move=> u0 Ha /(mxtrace_isRot u0); rewrite /angle=> ->.
-rewrite addrAC subrr add0r -(mulr_natr (cos a)) -mulrA divff; last first.
-  by rewrite pnatr_eq0.
+rewrite addrAC subrr add0r -(mulr_natr (cos a)) -mulrA divff ?pnatr_eq0//.
 by rewrite mulr1 cosKN // opprK.
 Qed.
 
@@ -1138,7 +1137,7 @@ have := sin0cos1 Hs; case: (ler0P (cos a)) => _ Hc; move: Ma; last first.
   by rewrite emx30M' // => ->; rewrite angle1; left.
 rewrite -eskew_unitE ?norm_normalize // ?vaxis_euler_neq0 //.
 rewrite eskew_unitE ?norm_normalize // ?vaxis_euler_neq0 //.
-rewrite eskew_pi' // ?norm_normalize // ?vaxis_euler_neq0 //; last first.
+rewrite eskew_pi' // ?norm_normalize // ?vaxis_euler_neq0 //.
   by rewrite -Hc opprK.
 move => ->; right.
 by rewrite anglepi // ?norm_normalize // ?vaxis_euler_neq0 //.
@@ -1149,8 +1148,8 @@ Proof.
 move=> MSO; case/SO_isRot : (MSO) => a aB HM.
 rewrite (mxtrace_isRot (vaxis_euler_neq0 MSO) HM).
 rewrite [1 + _]addrC addrK -[_ *+2]mulr_natr mulfK.
-  by rewrite cos_geN1 cos_le1.
-by rewrite (eqr_nat _ 2 0).
+  by rewrite (eqr_nat _ 2 0).
+by rewrite cos_geN1 cos_le1.
 Qed.
 
 Lemma angle_interval M : M \is 'SO[T]_3 -> 0 <= angle M <= pi.
@@ -1188,7 +1187,7 @@ Qed.
 Lemma angle0_tr M : M \is 'SO[T]_3 -> angle M = 0 -> \tr M = 3%:R.
 Proof.
 move=> MSO /(congr1 (fun x => cos x)).
-rewrite cos0 /angle acosK; last by apply tr_interval.
+rewrite cos0 /angle acosK; first exact: tr_interval.
 move/(congr1 (fun x => x * 2%:R)).
 rewrite -mulrA mulVr ?unitfE ?pnatr_eq0 // mulr1 mul1r.
 move/(congr1 (fun x => x + 1)).
@@ -1198,7 +1197,7 @@ Qed.
 Lemma angle_pi_tr M : M \is 'SO[T]_3 -> angle M = pi -> \tr M = - 1.
 Proof.
 move=> MSO /(congr1 (fun x => cos x)).
-rewrite cospi /angle acosK; last by apply tr_interval.
+rewrite cospi /angle acosK; first exact: tr_interval.
 move/(congr1 (fun x => x * 2%:R)).
 rewrite -mulrA mulVf ?pnatr_eq0 // mulr1.
 move/(congr1 (fun x => x + 1)).
@@ -1260,12 +1259,12 @@ have [M010 [M020 M001]] : M 0 1 = 0 /\ M 0 2%:R = 0 /\ M 0 0 = 1.
 have [P MP] : exists P : 'M[T]_2, M = block_mx (1 : 'M_1) 0 0 P.
   exists (@drsubmx _ 1 2 1 2 M).
   rewrite -{1}(@submxK _ 1 2 1 2 M).
-  rewrite (_ : ulsubmx _ = 1); last first.
+  rewrite (_ : ulsubmx _ = 1).
     apply/matrixP => i j.
-    rewrite (ord1 i) (ord1 j) !mxE /= -M001 mulr1n; congr (M _ _); by apply val_inj.
-  rewrite (_ : ursubmx _ = 0); last first.
+    by rewrite (ord1 i) (ord1 j) !mxE /= -M001 mulr1n; congr (M _ _); apply val_inj.
+  rewrite (_ : ursubmx _ = 0).
     apply/rowP => i.
-    case/boolP : (i == 0) => [|/ifnot01P]/eqP->;
+    by case/boolP : (i == 0) => [|/ifnot01P]/eqP->;
       [ rewrite !mxE -[RHS]M010; congr (M _ _); exact: val_inj |
         rewrite !mxE -[RHS]M020; congr (M _ _); exact: val_inj ].
   rewrite (_ : dlsubmx _ = 0) //.
@@ -1282,7 +1281,7 @@ split.
 case/rot2d : PSO => a /andP[a_geNpi a_lepi] PRO; rewrite {}PRO in MP.
 have := (angle_RO MP).
 case: (leP 0 a) => Ha /=; first by case=> -> // _; right; rewrite MP Rx_RO.
-case => _ -> //; last by rewrite (ltW a_geNpi) ltW.
+case => _ -> //; first by rewrite (ltW a_geNpi) ltW.
 by left; rewrite opprK MP Rx_RO.
 Qed.
 
@@ -1443,9 +1442,10 @@ apply: (@same_isRot _ _ _ _ (- `|Aa.vaxis M|_e *: w) ((sin (Aa.angle M) *+ 2) * 
   rewrite scale1r /w scaleNr norm_scale_normalize /Aa.vaxis (negbTE api).
   by rewrite tr_axial scalerN.
 - by rewrite -a_angle_of_rot //.
-rewrite isRotZN; first by rewrite opprK isRot_eskew // normalizeI.
-  by rewrite -enorm_eq0 w1 oner_neq0.
-by rewrite oppr_lt0 enorm_gt0 // Aa.vaxis_neq0.
+rewrite isRotZN.
+- by rewrite -enorm_eq0 w1 oner_neq0.
+- by rewrite oppr_lt0 enorm_gt0 // Aa.vaxis_neq0.
+- by rewrite opprK isRot_eskew // normalizeI.
 Qed.
 
 Lemma angle_axis_isRot (Q : 'M[T]_3) : axial Q != 0 ->
@@ -1466,7 +1466,7 @@ case/boolP : (Aa.angle Q == pi) => [api|api].
   apply isRotpi; by rewrite norm_normalize // vaxis_euler_neq0.
 have aB1: 0 < Aa.angle Q < pi by rewrite !lt_neqAle eq_sym a0 api.
 move=> [:vaxis0].
-rewrite {3}H isRotZ; last 2 first.
+rewrite {3}H isRotZ.
   abstract: vaxis0.
   rewrite /Aa.vaxis (negbTE api) scaler_eq0 negb_or Q0 andbT.
   rewrite invr_eq0 mulrn_eq0 /=.
@@ -1667,8 +1667,8 @@ case/boolP : (u *d F|,2%:R == 0) => [/eqP|] u2.
 have pi2B : - pi < (pi : T) / 2%:R <= pi.
   rewrite lter_pdivlMr ?ltr0n // ler_pdivrMr ?ltr0n //.
   rewrite -subr_gte0 mulNr opprK addr_gt0 ? pi_gt0 //.
-    by rewrite -subr_gte0 mulr_natr mulr2n addrK pi_ge0.
-  by rewrite mulr_natr mulr2n addr_gt0 // pi_gt0.
+    by rewrite mulr_natr mulr2n addr_gt0 // pi_gt0.
+  by rewrite -subr_gte0 mulr_natr mulr2n addrK pi_ge0.
 have piN2B : - pi < - ((pi : T) / 2%:R) <= pi.
   rewrite ltrN2 ltr_pdivrMr// ltr_pMr ?pi_gt0// ltr1n/=.
   by rewrite (le_trans _ (pi_ge0 T))// lerNl oppr0 divr_ge0// pi_ge0.
@@ -1725,32 +1725,32 @@ have [w [wB Hw1 Hw2]] :
   rewrite normu.
   move/(congr1 (fun x => x ^+ 2)).
   rewrite expr1n enormD !enormZ ?noframe_norm !mulr1.
-  rewrite (_ : cos _ = 0); last first.
+  rewrite (_ : cos _ = 0).
     case: (lerP 0 (u *d F|,2%:R)).
       rewrite le_eqVlt eq_sym (negbTE u2) /= => {}u2.
       case: (lerP 0 (u *d F|,1)).
         rewrite le_eqVlt eq_sym (negbTE u1) /= => {}u1.
-        rewrite vec_anglevZ; last by [].
-        rewrite vec_angleZv; last by [].
+        rewrite vec_anglevZ; first by [].
+        rewrite vec_angleZv; first by [].
         rewrite /vec_angle /= noframe_jdotk mul0r acos0.
         by rewrite (negPf f1D0) (negPf f2D0) cos_pihalf.
       move=> {}u1.
-        rewrite vec_angleZNv; last by [].
-        rewrite vec_anglevZ; last by [].
+        rewrite vec_angleZNv; first by [].
+        rewrite vec_anglevZ; first by [].
         rewrite cos_vec_angleNv //.
         rewrite /vec_angle noframe_jdotk mul0r acos0.
         by rewrite (negPf f1D0) (negPf f2D0) cos_pihalf oppr0.
       move=> {}u2.
       case: (lerP 0 (u *d F|,1)).
         rewrite le_eqVlt eq_sym (negbTE u1) /= => {}u1.
-        rewrite vec_angleZv; last by [].
-        rewrite vec_anglevZN; last by [].
+        rewrite vec_angleZv; first by [].
+        rewrite vec_anglevZN; first by [].
         rewrite cos_vec_anglevN //.
         rewrite /vec_angle noframe_jdotk mul0r acos0.
         by rewrite (negPf f1D0) (negPf f2D0) cos_pihalf oppr0.
       move=> {}u1.
-      rewrite vec_anglevZN; last by [].
-      rewrite vec_angleZNv; last by [].
+      rewrite vec_anglevZN; first by [].
+      rewrite vec_angleZNv; first by [].
       rewrite cos_vec_angleNv ?oppr_eq0 // cos_vec_anglevN //.
       rewrite opprK /vec_angle noframe_jdotk mul0r acos0.
       by rewrite (negPf f1D0) (negPf f2D0) cos_pihalf.
@@ -1777,7 +1777,7 @@ exists w; rewrite -{1}Hw1 -{1}Hw2; split => //.
 have <- : v *d F|,1 = - sin w.
   rewrite -Hw2 2!dotmul_cos normu 2!noframe_norm mul1r normv mulr1.
   rewrite [in LHS]mul1r [in RHS]mul1r ?opprK H'.
-  rewrite [in RHS]cos_vec_anglevN ?opprK; [by [] | | ].
+  rewrite [in RHS]cos_vec_anglevN ?opprK; [ | | by []].
   by rewrite -enorm_eq0 normv oner_neq0.
   by rewrite -enorm_eq0 noframe_norm oner_neq0.
 have <- : v *d F|,2%:R = cos w.
@@ -1844,9 +1844,9 @@ have Ha1 : a1 = col 0 R.
   case: ifPn => [/eqP ->|A1].
     by rewrite !mxE /= Kw3 !mulNr opprK -mulrA mulVr ?mulr1 // unitfE gt_eqF.
   rewrite -(negbK (a == 2%:R)) ifnot2 negb_or A0 A1 /= !mxE /= /w2 asinK.
-    suff /eqP -> : a == 2%:R by [].
-    by apply/negPn; rewrite ifnot2 negb_or A0.
-  by rewrite in_itv/= -ler_norml Oij_ub // rotation_sub.
+    by rewrite in_itv/= -ler_norml Oij_ub // rotation_sub.
+  suff /eqP -> : a == 2%:R by [].
+  by apply/negPn; rewrite ifnot2 negb_or A0.
 have Hw2 : sin w2 = R 2%:R 0.
   move/(congr1 (fun v : 'cV_3 => v 2%:R 0)) : Ha1; by rewrite !mxE.
 rewrite -(row_mx_colE R).
@@ -1854,8 +1854,8 @@ transitivity (row_mx (col 0 R) (row_mx a2 a3) *m Rx w1).
   rewrite Rx_RO.
   rewrite (mul_row_block _ _ 1) mulmx0 addr0 mulmx1 mulmx0 add0r.
   congr (row_mx (col 0 R)).
-  rewrite (_ : col 1 R = (row 1 R^T)^T); last by rewrite ?tr_row ?trmxK.
-  rewrite (_ : col 2%:R R = (row 2%:R R^T)^T); last by rewrite ?tr_row ?trmxK.
+  rewrite (_ : col 1 R = (row 1 R^T)^T); first by rewrite ?tr_row ?trmxK.
+  rewrite (_ : col 2%:R R = (row 2%:R R^T)^T); first by rewrite ?tr_row ?trmxK.
   rewrite -(trmxK a2).
   rewrite -(trmxK a3).
   have [k [k' [Hr2 Hr3]]] : exists k k',
@@ -1915,9 +1915,9 @@ exists (if 0 <= u``_0 then vec_angle n 'e_0 else - vec_angle n 'e_0).
   by rewrite Rz_eskew isRot_eskew ?normalizeI ?enorm_delta_mx.
 rewrite {1}e0row /Rz mulmx_row3_col3 ?(scale0r,scale1r,addr0).
 rewrite [in RHS]/n crossmulE.
-rewrite (_ : 'e_2%:R 0 1 = 0) ?(mul0r,add0r); last by rewrite mxE.
-rewrite (_ : 'e_2%:R 0 0 = 0) ?(mul0r,subrr,subr0); last by rewrite mxE.
-rewrite (_ : 'e_2%:R 0 2%:R = 1) ?mul1r; last by rewrite mxE.
+rewrite (_ : 'e_2%:R 0 1 = 0) ?(mul0r,add0r); first by rewrite mxE.
+rewrite (_ : 'e_2%:R 0 0 = 0) ?(mul0r,subrr,subr0); first by rewrite mxE.
+rewrite (_ : 'e_2%:R 0 2%:R = 1) ?mul1r; first by rewrite mxE.
 have ? : 'e_2%:R *v u != 0.
   apply/colinearP; case.
     by rewrite -enorm_eq0 u1 // oner_eq0.
@@ -1939,13 +1939,13 @@ rewrite /normalize row3Z mulr0; congr row3.
       ?enorm_delta_mx ?oner_neq0 //.
     case: ifPn => //; by rewrite sinN.
   rewrite /n /normalize crossmulE.
-  rewrite (_ : 'e_0%:R 0 2%:R = 0) ?(mulr0,subr0,add0r); last by rewrite mxE.
-  rewrite (_ : 'e_0%:R 0 1 = 0) ?(mulr0,oppr0,add0r); last by rewrite mxE.
-  rewrite (_ : 'e_0%:R 0 0 = 1) ?(mulr1); last by rewrite mxE.
+  rewrite (_ : 'e_0%:R 0 2%:R = 0) ?(mulr0,subr0,add0r); first by rewrite mxE.
+  rewrite (_ : 'e_0%:R 0 1 = 0) ?(mulr0,oppr0,add0r); first by rewrite mxE.
+  rewrite (_ : 'e_0%:R 0 0 = 1) ?(mulr1); first by rewrite mxE.
   rewrite crossmulE.
-  rewrite (_ : 'e_2%:R 0 1 = 0) ?(mul0r,add0r); last by rewrite mxE.
-  rewrite (_ : 'e_2%:R 0 0 = 0) ?(mul0r,subrr,subr0); last by rewrite mxE.
-  rewrite (_ : 'e_2%:R 0 2%:R = 1) ?(mul1r); last by rewrite mxE.
+  rewrite (_ : 'e_2%:R 0 1 = 0) ?(mul0r,add0r); first by rewrite mxE.
+  rewrite (_ : 'e_2%:R 0 0 = 0) ?(mul0r,subrr,subr0); first by rewrite mxE.
+  rewrite (_ : 'e_2%:R 0 2%:R = 1) ?(mul1r); first by rewrite mxE.
   rewrite !mxE mulr0 /=.
   rewrite -{2 3 5 6}(oppr0) -row3N enormN.
   rewrite [in LHS]mulrC -{2 3 5 6}(mulr0 (u``_0)) -row3Z.
@@ -1980,6 +1980,7 @@ apply/matrix3P/and9P; split;
   move: (sin c) => sc;
   rewrite !mxE /= sum3E !mxE /= !sum3E !mxE /=; Simp.r => //=.
 
+- by apply/eqP; nsatz.
 - by apply/eqP; nsatz.
 - by apply/eqP; nsatz.
 - by apply/eqP; nsatz.
@@ -2071,7 +2072,7 @@ apply: Rzyz_reduced_constraints => //.
   rewrite cos_atan2 ?oppr_eq0//.
   rewrite sqrrN sqr_M2jE // -/(yarc _).
   by rewrite mulrC mulrN -mulrA mulVf ?mulr1 ?opprK // yarc_neq0.
-- rewrite /zyz_b /zyz_c sqr_Mi2E; last by rewrite rotation_sub.
+- rewrite /zyz_b /zyz_c sqr_Mi2E ?rotation_sub//.
   rewrite -/(yarc _) sin_atan2_yarcx //.
   have [/eqP M02|M02] := boolP (M 0 2%:R == 0).
     rewrite M02 oppr0 sin_atan2_0.
@@ -2206,7 +2207,7 @@ apply: RxyzE_M02D1 => //.
     by rewrite (negbTE M01) mul0r.
   rewrite cos_atan2 // sqr_Mi2E // -/(yarc _) -mulrA.
   by rewrite mulVr ?mulr1 // unitfE yarc_neq0.
-- rewrite /rpy_a /rpy_b sqr_M0jE; last by rewrite rotation_sub.
+- rewrite /rpy_a /rpy_b sqr_M0jE; first by rewrite rotation_sub.
   rewrite -/(yarc _) cos_atan2_xyarc //.
   have [/eqP M00|M00] := boolP (M 0 0 == 0).
     rewrite M00 sin_atan2_0.
@@ -2285,7 +2286,7 @@ have [/eqP NM02E1|NM02D1] := boolP (`|M 0 2%:R| == 1); last first.
       move H : (_ == 0) => h; case: h H => H.
         by rewrite mul1r (eqP H).
       by rewrite mul0r.
-    rewrite cos_atan2; last first.
+    rewrite cos_atan2.
       by rewrite mulf_neq0 // invr_eq0 -/(yarc _) yarc_neq0.
     rewrite -/(yarc _).
     rewrite mulrAC -(mulrA (M 0 0)) mulVr ?unitfE ?yarc_neq0 // mulr1.
@@ -2295,7 +2296,7 @@ have [/eqP NM02E1|NM02D1] := boolP (`|M 0 2%:R| == 1); last first.
     have [M00|M00] := eqVneq (M 0 0) 0.
       rewrite M00 mul0r sin_atan2_0 sgrM sgrV -mulrA -normrEsg.
       by rewrite -sqr_Mi2E // M00 expr0n add0r sqrtr_sqr normr_id -numEsg.
-    rewrite sin_atan2; last first.
+    rewrite sin_atan2.
       by rewrite mulf_neq0 // -/(yarc _) invr_eq0 yarc_neq0.
     rewrite -/(yarc _).
     (* NB: same as above *)
@@ -2308,7 +2309,7 @@ have [/eqP NM02E1|NM02D1] := boolP (`|M 0 2%:R| == 1); last first.
       rewrite M22 mul0r sin_atan2_0 sgrM sgrV mulrCA -[_ * Num.sg _]mulrC.
       rewrite -normrEsg -sqr_M0jE //.
       by rewrite M22 expr0n addr0 sqrtr_sqr normr_id -numEsg.
-    rewrite sin_atan2; last first.
+    rewrite sin_atan2.
       by rewrite mulf_neq0 // -/(yarc _) invr_eq0 yarc_neq0.
     rewrite -/(yarc _).
     (* NB: same as above *)
@@ -2322,7 +2323,7 @@ have [/eqP NM02E1|NM02D1] := boolP (`|M 0 2%:R| == 1); last first.
     rewrite mulf_eq0 invr_eq0 sqrtr_eq0 le_eqVlt sqrf_eq0.
     rewrite ltNge sqr_ge0 orbF.
     by case: eqP => [->|] /=; rewrite ?(mul0r, mulr0, expr0n, sqrtr0).
-  rewrite cos_atan2; last first.
+  rewrite cos_atan2.
     by rewrite mulf_neq0 // -/(yarc _) invr_eq0 yarc_neq0.
   rewrite -/(yarc _).
   (* NB: same as above *)

--- a/rot.v
+++ b/rot.v
@@ -1,7 +1,7 @@
 (* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From HB Require Import structures.
 From Stdlib Require Import NsatzTactic.
-From mathcomp Require Import all_boot order ssralg ssrint ssrnum rat poly.
+From mathcomp Require Import boot order ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import ssrAC.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import realalg reals complex.

--- a/scara.v
+++ b/scara.v
@@ -119,7 +119,7 @@ Proof.
 rewrite /t1 /rjoint_twist.
 rewrite (linearNl _ q1)/=.
 rewrite (linear0r _ w1)/=.
-rewrite oppr0 etwist_Rz; last first.
+rewrite oppr0 etwist_Rz.
   by rewrite -enorm_eq0 enormeE oner_eq0.
 by rewrite -Rz_eskew.
 Qed.

--- a/scara.v
+++ b/scara.v
@@ -1,5 +1,5 @@
 (* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
-From mathcomp Require Import all_boot ssralg ssrint ssrnum rat poly.
+From mathcomp Require Import boot ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import realalg complex fingroup perm.
 From mathcomp Require Import sesquilinear.

--- a/screw.v
+++ b/screw.v
@@ -1,6 +1,6 @@
 (* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From HB Require Import structures.
-From mathcomp Require Import all_boot order ssralg ssrint ssrnum rat poly.
+From mathcomp Require Import boot order ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import realalg complex fingroup perm.
 From mathcomp Require Import sesquilinear.

--- a/screw.v
+++ b/screw.v
@@ -220,8 +220,10 @@ move=> x y z; rewrite /sq.
 rewrite mulrBr (mulrBl z) opprB !addrA addrC !addrA (mulrA x).
 rewrite (addrC _ (x * y * z)) subrr add0r.
 rewrite (mulrBl y) opprB addrA (addrC _ (x * z * y)) mulrA !addrA subrr add0r.
-rewrite (mulrBr y) !addrA (addrC _ (- (y * (x * z)))) addrC !addrA mulrA subrr.
-by rewrite add0r mulrBl opprB mulrA subrK mulrBr addrA mulrA subrK mulrA subrr.
+rewrite mulrBl opprB 2!mulrBr !mulrA.
+rewrite -!addrA (addrA (- (y * z * x))) addNr add0r.
+rewrite (addrA (- (z * x * y))) addNr add0r.
+by rewrite (addrCA (- (y * x * z))) addNr addr0 subrr.
 Qed.
 
 HB.instance Definition _ :=
@@ -618,7 +620,7 @@ Qed.
 (* [murray] eqn 2.32, p.41 *)
 Lemma emx_twist0E v k : emx (wedge \T(v, 0)) k.+2 = hom 1 v.
 Proof.
-rewrite /emx 2!big_ord_recl big1 ?addr0; last first.
+rewrite /emx 2!big_ord_recl big1 ?addr0.
   move=> /= i _; by rewrite ecoefE exp_twist0v scaler0.
 rewrite liftE0 eqxx /ecoef factS fact0 expr0 expr1 invr1 2!scale1r.
 rewrite /wedge Twist.ang_of Twist.lin_of spin0.
@@ -681,7 +683,7 @@ Proof.
 move=> w1 g h.
 rewrite {1}/emx 2!big_ord_recl big_ord0 addr0 liftE0 eqxx /ecoef factS fact0 invr1 2!scale1r.
 rewrite expr0 expr1.
-rewrite (_ : 1 = @block_mx _ 3 _ 3 _ 1 0 0 1); last first.
+rewrite (_ : 1 = @block_mx _ 3 _ 3 _ 1 0 0 1).
   by rewrite -idmxE (@scalar_mx_block _ 3 1 1).
 rewrite tcoorZ /=.
 rewrite /wedge Twist.ang_of Twist.lin_of (add_block_mx 1 0 0 1 \S( a *: w )) !(addr0,add0r).
@@ -732,16 +734,16 @@ Lemma emx_twistE (t : twist T) a k :
 Proof.
 set v := lin_of_twist (wedge t).
 set w := ang_of_twist (wedge t).
-rewrite (_ : t = \T(v, w)); last first.
+rewrite (_ : t = \T(v, w)).
   by rewrite -(twist_mkE t) lin_of_twist_wedge ang_of_twist_wedge.
 case/boolP : (w == 0) => [/eqP ->|w0].
   rewrite tcoorZ /= scaler0 emx_twist0E.
   by rewrite /emx_twist /hom_twist ang_tcoorE eqxx lin_tcoorE.
 set w' : 'rV_3 := a *: w.
-rewrite -(norm_scale_normalize w) (_ : v = `|w|_e *: ((`|w|_e)^-1 *: v)); last first.
+rewrite -(norm_scale_normalize w) (_ : v = `|w|_e *: ((`|w|_e)^-1 *: v)).
   by rewrite scalerA divrr ?scale1r // unitfE enorm_eq0.
 rewrite -(tcoorZ `|w|_e ((`|w|_e)^-1 *: v) (normalize w)).
-rewrite scalerA p42eq235 p42eq3; last by rewrite norm_normalize.
+rewrite scalerA p42eq235 p42eq3 ?norm_normalize//.
 rewrite -mulmxE.
 rewrite {1}/rigid_trans mulmxE homM mul1r.
 rewrite inv_rigid_transE /inv_rigid_trans homM mulr1 mulmx1.
@@ -882,7 +884,7 @@ case/boolP : (sin a == 0) => [|saD0].
   by rewrite divff ?pnatr_eq0 // scale1r addrC subrr.
 rewrite {1}cot_half_angle' -!mulrA mulVf // mulr1 cot_half_angle.
 rewrite (scalerN (2%:R^-1 * _)) opprK (scalerA (2%:R^-1 * _)).
-rewrite -!mulrA mulVf ?mulr1; last first.
+rewrite -!mulrA mulVf ?mulr1.
   rewrite subr_eq0 eq_sym; apply: contra saD0 => /eqP caE.
   by rewrite cos1sin0 // caE normr1.
 rewrite -!addrA addrCA addrC !addrA.
@@ -965,7 +967,7 @@ have rank_wC : \rank (w^C)%MS = 2%N by rewrite mxrank_compl rank_w.
 have rank_kskew : \rank (kermx \S(w)) = 1%N by rewrite -[RHS]rank_w (eqmx_rank (kernel_spin w0)).
 have rank_skew : \rank \S(w) = 2%N.
   move: rank_kskew; rewrite mxrank_ker => /eqP.
-  rewrite -(eqn_add2r (\rank \S(w))) subnK; last by rewrite rank_leq_row.
+  rewrite -(eqn_add2r (\rank \S(w))) subnK; first by rewrite rank_leq_row.
   rewrite add1n => /eqP[] <-; by apply/eqP.
 move: (kernel_spin w0) => H.
 Abort.
@@ -1011,7 +1013,7 @@ case/boolP : (a == pi) => [/eqP ->|api].
   by rewrite mulrC.
 congr row3; last first.
   rewrite mulrN mulrBl opprB -!addrA addrC !addrA -mulrA subrK.
-  rewrite cot_half_angle' -!mulrA (mulrCA _ a2) mulVf ?mulr1; last first.
+  rewrite cot_half_angle' -!mulrA (mulrCA _ a2) mulVf ?mulr1.
     by rewrite sin_eq0_Npipi // negb_or a0 api.
   rewrite addrC -mulrBr opprD mulrDl mul1r -!addrA (addrCA _ (- a1)) (mulrC _ a2) subrr addr0.
   by rewrite -mulNr opprB mulrC.
@@ -1115,7 +1117,7 @@ rewrite [in X in _ = _ *: (X + _)]mulNmx.
 rewrite [in X in _ = _ *: (X + _)]mulmxBl.
 rewrite opprB -addrA.
 rewrite scalerDr.
-rewrite -[in X in _ = X + _]scalemxAl scalerA [in X in _ = X + _]mulrC divrr ?scale1r; last first.
+rewrite -[in X in _ = X + _]scalemxAl scalerA [in X in _ = X + _]mulrC divrr ?scale1r.
   by rewrite unitfE expf_eq0 /= enorm_eq0.
 congr (_ + _).
 rewrite -[in X in _ = _ *: (_ + X)]scalemxAl.
@@ -1127,7 +1129,7 @@ rewrite scalerDr.
 rewrite 2!scalerA.
 rewrite [in X in _ = X + _]mulrA.
 rewrite [in X in _ = X + _]mulrC.
-rewrite -(mulrA (a * h)) divrr ?mulr1; last by rewrite unitfE expf_eq0 /= enorm_eq0.
+rewrite -(mulrA (a * h)) divrr ?mulr1; first by rewrite unitfE expf_eq0 /= enorm_eq0.
 rewrite mulrC -[LHS]addr0.
 congr (_ + _).
 rewrite mulmxBr mulmx1.
@@ -1283,7 +1285,7 @@ rewrite -scalemxAl mulmxA dotmulP scalemxAl scalerDr -scalemxAl.
 rewrite (scalerA _ a) (mulrC _ a).
 rewrite -(scalerA a (`|w|_e ^+ 2)^-1).
 rewrite mul_scalar_mx (scalerA _ (v *d w) w) -(dotmulZv v _ w).
-rewrite (_ : _ *d _ = pitch \T(v, w)); last by rewrite /pitch lin_tcoorE ang_tcoorE.
+rewrite (_ : _ *d _ = pitch \T(v, w)); first by rewrite /pitch lin_tcoorE ang_tcoorE.
 rewrite addrC.
 rewrite scalerA.
 rewrite /axis ang_tcoorE (negbTE w0) /=.
@@ -1598,7 +1600,7 @@ have step2 : displacement f q + relative_displacement f p0 q = displacement f q 
   transitivity (displacement f p0 *m w^T *m w).
     rewrite -(displacement_iso f p0 q) {1}(axialnormalcomp (displacement f p0) w).
     move/(MozziChasles w0 sina0) : fp0e0.
-    rewrite -normalcomp_colinear; last by rewrite normalize_eq0.
+    rewrite -normalcomp_colinear; first by rewrite normalize_eq0.
     move/eqP => ->.
     by rewrite addr0 axialcompE w1 expr1n invr1 scale1r.
   by rewrite dotmulP mulmxA dotmulP 2!(displacement_proj w0).
@@ -1622,9 +1624,9 @@ have {step2} : p0 *m A = b.
 move/(congr1 (fun x => x *m A^T)).
 move/(congr1 (fun x => x *m screw_axis_point_mat_inv)).
 rewrite /screw_axis_point.
-rewrite (_ : screw_axis_point_mat_inv = (A *m A^T)^-1); last first.
+rewrite (_ : screw_axis_point_mat_inv = (A *m A^T)^-1).
   by rewrite screw_axis_point_mat_invE.
-rewrite -2!(mulmxA p0) mulmxV; last by rewrite screw_axis_point_mat_unit.
+rewrite -2!(mulmxA p0) mulmxV; first by rewrite screw_axis_point_mat_unit.
 rewrite mulmx1 screw_axis_point_mat_invE //.
 rewrite step3.
 rewrite mulmxBr mulmx1 /displacement opprB addrA subrK.
@@ -1674,15 +1676,15 @@ Let twist_b := \T( - map_v w_a *v map_p q_a + h *: map_v w_a, map_v w_a ).
 
 Lemma twist_change_frame : twist_b = twist_a *m (Adjoint g_ab)^-1.
 Proof.
-rewrite -(@inv_AdjointE _ (hom_of_euclidean_motion g_ab)); last first.
+rewrite -(@inv_AdjointE _ (hom_of_euclidean_motion g_ab)).
   by rewrite EuclideanMotion.hom_of_is_SE3.
 rewrite /inv_Adjoint.
-rewrite (_ : rot_of_hom g_ab = EuclideanMotion.rot g_ab); last first.
+rewrite (_ : rot_of_hom g_ab = EuclideanMotion.rot g_ab).
   case: g_ab => -[t r] /= Hr.
   rewrite /EuclideanMotion.rot /=.
   rewrite /hom_of_euclidean_motion /EuclideanMotion.hom_of.
   by rewrite rot_of_hom_hom.
-rewrite (_ : trans_of_hom g_ab = EuclideanMotion.trans g_ab); last first.
+rewrite (_ : trans_of_hom g_ab = EuclideanMotion.trans g_ab).
   case: g_ab => -[t r] /= Hr.
   rewrite /EuclideanMotion.rot /=.
   rewrite /hom_of_euclidean_motion /EuclideanMotion.hom_of.
@@ -1711,10 +1713,10 @@ congr (@block_mx _ 1 0 3 3).
   rewrite (linearNl _ (- (EuclideanMotion.trans g_ab *m (EuclideanMotion.rot g_ab)^T)))/=.
   rewrite (linearNr _ (w_a *m (EuclideanMotion.rot g_ab)^T))/=.
   rewrite opprK.
-  rewrite -spin_similarity; last by rewrite rotationV EuclideanMotion.rotP.
-  rewrite trmxK mulrA mulNr -mulmxE mulmxA orthogonal_tr_mul ?mul1mx; last first.
+  rewrite -spin_similarity; first by rewrite rotationV EuclideanMotion.rotP.
+  rewrite trmxK mulrA mulNr -mulmxE mulmxA orthogonal_tr_mul ?mul1mx.
     by rewrite rotation_sub // EuclideanMotion.rotP.
-  rewrite mulNmx mulmxN mulmxA spinE -mulmxr_crossmulr_SO; last first.
+  rewrite mulNmx mulmxN mulmxA spinE -mulmxr_crossmulr_SO.
     by rewrite rotationV EuclideanMotion.rotP.
   by rewrite (@lieC _ (vec3 T)) /= linearNl.
 - by rewrite /map_v coortrans_vectorE EuclideanMotion.rot_inv.

--- a/skew.v
+++ b/skew.v
@@ -1,6 +1,6 @@
 (* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From HB Require Import structures.
-From mathcomp Require Import all_boot ssralg ssrint ssrnum rat poly.
+From mathcomp Require Import boot ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import sesquilinear.
 From mathcomp Require Import realalg complex finset fingroup perm.
@@ -59,10 +59,8 @@ End keyed_qualifiers_anti_sym.
 Notation "''so[' R ]_ n" := (anti n R).
 
 Section sym_anti.
-
-Variables (R : pzRingType) (n : nat).
-Implicit Types M A B : 'M[R]_n.
-Implicit Types v : 'rV[R]_n.
+Context {R : pzRingType} {n : nat}.
+Implicit Types (M A B : 'M[R]_n) (v : 'rV[R]_n).
 
 Section sym.
 
@@ -84,10 +82,7 @@ wlog : i j ij / (i < j)%N.
 by move=> {}ij; rewrite AB // leq_eqVlt ij orbC.
 Qed.
 
-Lemma sym_oppr_closed : oppr_closed (sym n R).
-Proof. move=> /= M /eqP HM; apply/eqP; by rewrite linearN /= -HM. Qed.
-
-Lemma sym_addr_closed : addr_closed (sym n R).
+Let sym_addr_closed : Algebra.nmod_closed (sym n R).
 Proof.
 split; first by rewrite symE trmx0.
 move=> /= A B; rewrite 2!symE => /eqP sA /eqP sB.
@@ -95,11 +90,14 @@ by rewrite symE linearD /= -sA -sB.
 Qed.
 
 HB.instance Definition _ := GRing.isAddClosed.Build _ _ sym_addr_closed.
+
+Let sym_oppr_closed : oppr_closed (sym n R).
+Proof. move=> /= M /eqP HM; apply/eqP; by rewrite linearN /= -HM. Qed.
+
 HB.instance Definition _ := GRing.isOppClosed.Build _ _ sym_oppr_closed.
 
 Lemma sym_scaler_closed : GRing.scaler_closed (sym n R).
 Proof. move=> ? ?; rewrite 2!symE => /eqP H; by rewrite linearZ /= -H. Qed.
-(* TODO: Canonical? *)
 
 HB.instance Definition _ := GRing.isScaleClosed.Build _ _ _ sym_scaler_closed.
 
@@ -541,8 +539,7 @@ Implicit Types M : 'M[R]_3.
 Lemma sqr_spin u : \S( u ) ^+ 2 = u^T *m u - (`|u|_e ^+ 2)%:A.
 Proof.
 apply (symP (sqr_spin_is_sym u)); last move=> i j.
-  rewrite rpredD//= ?mul_tr_vec_sym//.
-  by rewrite sym_oppr_closed (*TODO: why can't we use rpredN*)// sym_scaler_closed// sym_cst.
+  by rewrite rpredB//= ?mul_tr_vec_sym// rpredZ//= sym_cst.
 rewrite [in X in _ -> _ = X]mxE mulmx_trE.
 case/boolP : (i == 0) => [/eqP-> _|/ifnot0P/orP[]/eqP->].
 - case/boolP : (j == 0) => [|/ifnot0P/orP[]]/eqP->.

--- a/skew.v
+++ b/skew.v
@@ -3,7 +3,8 @@ From HB Require Import structures.
 From mathcomp Require Import all_boot ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import sesquilinear.
-From mathcomp Require Import realalg complex finset fingroup perm ring.
+From mathcomp Require Import realalg complex finset fingroup perm.
+From mathcomp Require Import ring_tactic field_tactic.
 Require Import ssr_ext euclidean vec_angle.
 From mathcomp Require Import reals.
 
@@ -494,7 +495,7 @@ Proof. by rewrite -(spin_axial M) spinK. Qed.
 
 Lemma axial_vecP (M : 'M[R]_3) u : axial M *v u  = u *m (2%:R *: antip M).
 Proof.
-rewrite axialE -spinE (_ : _ - _ = 2%:R *: antip M); last first.
+rewrite axialE -spinE (_ : _ - _ = 2%:R *: antip M).
   by rewrite scalerA mulrC divfK ?scale1r // (eqr_nat _ 2 0).
 by rewrite unspinZ spinZ unspinK ?antip_is_so.
 Qed.
@@ -606,8 +607,8 @@ Qed.
 Definition spin_eigenvalues u : seq R[i] := [:: 0; 0 +i* `|u|_e ; 0 -i* `|u|_e]%C.
 
 Ltac eigenvalue_spin_eval_poly :=
-  rewrite /map_poly horner_poly size_polyDl; [ |
-    by rewrite size_polyXn size_scale ?size_polyX // sqrf_eq0 enorm_eq0];
+  rewrite /map_poly horner_poly size_polyDl; [
+    by rewrite size_polyXn size_scale ?size_polyX // sqrf_eq0 enorm_eq0 | ];
   rewrite size_polyXn sum4E !(coefD,coefXn,coefZ,coefX,expr0,expr1)
                             !(mulr0,mul0r,mul1r,add0r,addr0,mul1r).
 
@@ -771,7 +772,7 @@ rewrite {3}(skew_anti Mso) linearN /= trmxK.
 rewrite trmxV linearD /= trmx1 linearN /=.
 rewrite {4}(skew_anti Mso) !linearN /= trmxK opprK.
 rewrite -!mulmxE.
-rewrite mulmxA -(mulmxA _^-1) -mul1B1D_comm mulmxA mulVmx ?mul1mx; last first.
+rewrite mulmxA -(mulmxA _^-1) -mul1B1D_comm mulmxA mulVmx ?mul1mx.
   by rewrite unitmxE unitfE skew_det1BM.
 by rewrite mulmxV // unitmxE unitfE skew_det1DM.
 Qed.
@@ -792,11 +793,11 @@ Definition uncayley n (M : 'M[R]_n.+1) := (M - 1) * (M + 1)^-1.
 Lemma ortho_N1eigen_comm n (M : 'M[R]_n.+1) : M \is 'O[R]_n.+1 ->
   -1 \notin eigenvalue M -> M * (M + 1)^-1 = (M + 1)^-1 * M.
 Proof.
-move=> MO MN1; rewrite -{1}(invrK M) -invrM; last 2 first.
+move=> MO MN1; rewrite -{1}(invrK M) -invrM.
   by rewrite ortho_N1eigen_invertible.
   by rewrite orthogonal_inv // unitr_trmx ?orthogonal_unit.
 rewrite mulrDl divrr ?orthogonal_unit // div1r (orthogonal_inv MO).
-rewrite -{1}(orthogonal_tr_mul MO) -{2}(mulr1 M^T) -mulrDr invrM; last 2 first.
+rewrite -{1}(orthogonal_tr_mul MO) -{2}(mulr1 M^T) -mulrDr invrM.
   by rewrite unitr_trmx orthogonal_unit.
   by rewrite ortho_N1eigen_invertible.
 by rewrite -trmxV (orthogonal_inv MO) trmxK.
@@ -811,9 +812,9 @@ rewrite {1}mulrBl mul1r ortho_N1eigen_comm // -[X in _ - X]mulr1 -mulrBr.
 rewrite trmx_mul mulmxE trmxV !linearD /= linearN /= trmx1.
 rewrite /uncayley -(mulr1 (M - 1)) -[X in _ * X / _](orthogonal_tr_mul MO).
 rewrite mulrA mulrDl mulNr mul1r -(orthogonal_inv MO) divrr ?orthogonal_unit//.
-rewrite -mulrA -[X in _ * (X * _)](invrK M) -invrM; last 2 first.
-  by rewrite ortho_N1eigen_invertible.
-  by rewrite unitrV orthogonal_unit.
+rewrite -mulrA -[X in _ * (X * _)](invrK M) -invrM.
+- by rewrite ortho_N1eigen_invertible.
+- by rewrite unitrV orthogonal_unit.
 rewrite (mulrDl _ _ M^-1) divrr ?orthogonal_unit// mul1r (addrC 1 M^-1).
 by rewrite -mulNr opprB.
 Qed.

--- a/ssr_ext.v
+++ b/ssr_ext.v
@@ -1,6 +1,6 @@
-(* robot-rocq (c) 2017 AIST and INRIA. License: LGPL-2.1-or-later. *)
+(* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
 From Stdlib Require Import NsatzTactic.
-From mathcomp Require Import all_boot ssralg ssrnum ssrint rat poly.
+From mathcomp Require Import boot ssralg ssrnum ssrint rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import perm path fingroup complex.
 

--- a/vec_angle.v
+++ b/vec_angle.v
@@ -1,5 +1,5 @@
 (* robot-rocq (c) 2026 AIST and INRIA. License: LGPL-2.1-or-later. *)
-From mathcomp Require Import all_boot all_order ssralg ssrint ssrnum rat poly.
+From mathcomp Require Import boot order ssralg ssrint ssrnum rat poly.
 From mathcomp Require Import closed_field polyrcf matrix mxalgebra mxpoly zmodp.
 From mathcomp Require Import sesquilinear.
 From mathcomp Require Import realalg complex fingroup perm reals interval trigo.

--- a/vec_angle.v
+++ b/vec_angle.v
@@ -132,8 +132,8 @@ Proof.
 move=> u0 v0.
 rewrite in_itv /= -ler_norml -(expr_le1 (_ : 0 < 2)%N) //.
 rewrite sqr_normr expr_div_n ler_pdivrMr ?mul1r.
-rewrite -subr_ge0 -enorm_crossmul' ?exprn_ge0 ?enorm_ge0//.
-by rewrite exprn_gt0// mulr_gt0// enorm_gt0.
+  by rewrite exprn_gt0// mulr_gt0// enorm_gt0.
+by rewrite -subr_ge0 -enorm_crossmul' ?exprn_ge0 ?enorm_ge0.
 Qed.
 
 Lemma cos_vec_angleNv v w : v != 0 -> w != 0 ->
@@ -177,7 +177,7 @@ wlog /andP[u0 v0] : u v / (u != 0) && (v != 0).
   have [->|u0] := eqVneq u 0; first by rewrite dotmul0v enorm0 !mul0r.
   have [->|v0] := eqVneq v 0; first by rewrite dotmulv0 enorm0 !(mulr0,mul0r).
   by apply; rewrite u0.
-rewrite /vec_angle (negPf u0) (negPf v0) acosK; last exact: dotmul_div_N11.
+rewrite /vec_angle (negPf u0) (negPf v0) acosK; first exact: dotmul_div_N11.
 by rewrite mulrC divfK // mulf_eq0 negb_or !enorm_eq0 u0.
 Qed.
 
@@ -208,7 +208,7 @@ Qed.
 Lemma enormB u v : `|u - v|_e ^+ 2 =
   `|u|_e ^+ 2 + `|u|_e * `|v|_e * cos (vec_angle u v) *- 2 + `|v|_e ^+ 2.
 Proof.
-rewrite /enorm dotmulD {1}dotmulvv sqr_sqrtr; last first.
+rewrite /enorm dotmulD {1}dotmulvv sqr_sqrtr.
   rewrite !dotmulvN !dotmulNv opprK dotmulvv dotmul_cos.
   by rewrite addrAC mulNrn subr_ge0 triine.
 rewrite sqr_sqrtr ?le0dotmul // !dotmulvv !sqrtr_sqr enormN dotmulvN dotmul_cos.
@@ -219,7 +219,7 @@ Qed.
 Lemma enormD u v : `|u + v|_e ^+ 2 =
   `|u|_e ^+ 2 + `|u|_e * `|v|_e * cos (vec_angle u v) *+ 2 + `|v|_e ^+ 2.
 Proof.
-rewrite {1}(_ : v = - - v); last by rewrite opprK.
+rewrite {1}(_ : v = - - v); first by rewrite opprK.
 rewrite enormB enormN.
 have [->|u0] := eqVneq u 0.
   by rewrite !(enorm0,expr0n,add0r,vec_angle0,mul0r,mul0rn,oppr0).
@@ -232,7 +232,7 @@ Lemma cosine_law' a b c :
   `|b - c|_e ^+ 2 = `|c - a|_e ^+ 2 + `|b - a|_e ^+ 2 -
   `|c - a|_e * `|b - a|_e * cos (vec_angle (b - a) (c - a)) *+ 2.
 Proof.
-rewrite -[in LHS]dotmulvv (_ : b - c = b - a - (c - a)); last first.
+rewrite -[in LHS]dotmulvv (_ : b - c = b - a - (c - a)).
   by rewrite -!addrA opprB (addrC (- a)) (addrC a) addrK.
 rewrite dotmulD dotmulvv [in X in _ + _ + X = _]dotmulvN dotmulNv opprK.
 rewrite dotmulvv dotmulvN addrAC (addrC (`|b - a|_e ^+ _)); congr (_ + _).
@@ -259,13 +259,14 @@ Lemma enorm_crossmul u v :
   `|u *v v|_e = `|u|_e * `|v|_e * `| sin (vec_angle u v) |.
 Proof.
 suff /eqP : `|u *v v|_e ^+ 2 = (`|u|_e * `|v|_e * `| sin (vec_angle u v) |)^+2.
-  rewrite -eqr_sqrt ?sqr_ge0 // 2!sqrtr_sqr ger0_norm; last by rewrite enorm_ge0.
-  rewrite ger0_norm; first by move/eqP.
+  rewrite -eqr_sqrt ?sqr_ge0 // 2!sqrtr_sqr ger0_norm ?enorm_ge0//.
+  rewrite ger0_norm; last by move/eqP.
   by rewrite -mulrA mulr_ge0 ?enorm_ge0 // mulr_ge0 // enorm_ge0.
 rewrite enorm_crossmul' dotmul_cos !exprMn.
 apply/eqP; rewrite subr_eq -mulrDr.
-rewrite real_normK //; first by rewrite addrC cos2Dsin2 mulr1.
-by rewrite realE; case: ltgtP.
+rewrite real_normK //.
+  by rewrite realE; case: ltgtP.
+by rewrite addrC cos2Dsin2 mulr1.
 Qed.
 
 Lemma enorm_dotmul_crossmul u v : u != 0 -> v != 0 ->
@@ -284,8 +285,8 @@ Proof.
 move=> uD0 vD0 uv0.
 apply/eqP; rewrite -subr_eq0 -enorm_eq0.
 rewrite -(@eqrXn2 _ 2) ?enorm_ge0// expr0n /= enormB.
-rewrite vec_anglevZ; last by rewrite divr_gt0// enorm_gt0.
-rewrite uv0 cos0 mulr1 !enormZ ger0_norm; last first.
+rewrite vec_anglevZ ?divr_gt0 ?enorm_gt0//.
+rewrite uv0 cos0 mulr1 !enormZ ger0_norm.
   by rewrite divr_ge0// enorm_ge0.
 by rewrite divfK ?enorm_eq0// -expr2 addrAC -mulr2n subrr.
 Qed.
@@ -296,8 +297,8 @@ Proof.
 move=> uD0 vD0 uvpi.
 apply/eqP; rewrite -subr_eq0 -enorm_eq0 scaleNr opprK.
 rewrite -(@eqrXn2 _ 2) ?enorm_ge0// expr0n /= enormD.
-rewrite vec_anglevZ; last by rewrite divr_gt0// enorm_gt0.
-rewrite uvpi cospi mulrN1 !enormZ ger0_norm; last first.
+rewrite vec_anglevZ ?divr_gt0 ?enorm_gt0//.
+rewrite uvpi cospi mulrN1 !enormZ ger0_norm.
   by rewrite divr_ge0// enorm_ge0.
 rewrite mulNrn divfK ?enorm_eq0//.
 by rewrite addrC addrA -expr2 -mulr2n subrr.
@@ -334,8 +335,8 @@ Lemma cos_vec_angle a b : a != 0 -> b != 0 ->
 Proof.
 move=> Ha Hb.
 rewrite enorm_crossmul mulrAC divrr // ?mul1r.
-  by rewrite sqr_normr -cos2sin2 sqrtr_sqr.
-by rewrite unitfE mulf_neq0// enorm_eq0.
+  by rewrite unitfE mulf_neq0// enorm_eq0.
+by rewrite sqr_normr -cos2sin2 sqrtr_sqr.
 Qed.
 
 Lemma orth_preserves_vec_angle M : M \is 'O[T]_3 ->
@@ -402,7 +403,7 @@ Qed.
 Lemma colinear_permE (T : idomainType) (s : 'S_3) (u v : 'rV[T]_3) :
   colinear u v = colinear (col_perm s u) (col_perm s v).
 Proof.
-rewrite /colinear !col_permE -mulmx_crossmul; last exact: unitmx_perm.
+rewrite /colinear !col_permE -mulmx_crossmul; first exact: unitmx_perm.
 rewrite -scalemxAr scalemx_eq0 det_perm signr_eq0 /=.
 by rewrite perm_mxV invrK tr_perm_mx -col_permE col_perm_eq0.
 Qed.
@@ -480,13 +481,13 @@ rewrite -norm_cos_eq1 -cos0 => /eqP.
 have [c_le0|c_gt0 Hc] := ler0P (cos (vec_angle u v)).
   rewrite -cos_vec_anglevN // -colinearvN => Hc.
   rewrite (vec_angle0_inv uD0 vND0).
-    by rewrite colinearZv colinearvv orbT.
-  apply: cos_inj => //; rewrite in_itv /= ?(lexx, pi_ge0) //.
-  by apply: vec_angle_bound.
-rewrite (vec_angle0_inv uD0 vD0).
+    apply: cos_inj => //; rewrite in_itv /= ?(lexx, pi_ge0) //.
+    exact: vec_angle_bound.
   by rewrite colinearZv colinearvv orbT.
-apply: cos_inj => //; rewrite in_itv /= ?(lexx, pi_ge0) //.
-by apply: vec_angle_bound.
+rewrite (vec_angle0_inv uD0 vD0).
+  apply: cos_inj => //; rewrite in_itv /= ?(lexx, pi_ge0) //.
+  exact: vec_angle_bound.
+by rewrite colinearZv colinearvv orbT.
 Qed.
 
 Lemma sin_vec_angle_iff (u v : 'rV[T]_3) (u0 : u != 0) (v0 : v != 0) :
@@ -566,7 +567,7 @@ Lemma enorm_axialcomp v e : e *d v < 0 ->
 Proof.
 move=> H.
 have ? : e != 0 by apply: contraTN H => /eqP ->; rewrite dotmul0v ltxx.
-rewrite /axialcomp scalerA enormZ ltr0_norm; last first.
+rewrite /axialcomp scalerA enormZ ltr0_norm.
   rewrite pmulr_llt0 ?invr_gt0 ?enorm_gt0 //.
   by rewrite /normalize dotmulZv pmulr_rlt0 // invr_gt0 enorm_gt0.
 by rewrite mulNr -(mulrA _ _ `|e|_e) mulVr ?mulr1 ?unitfE ?enorm_eq0.
@@ -773,20 +774,20 @@ have v10 : v1 != 0 by apply: contra H => /eqP ->; rewrite colinear0.
 have v20 : v2 != 0 by apply: contra H => /eqP ->; rewrite colinear_sym colinear0.
 rewrite /normalcomp [in RHS]enormB.
 case/boolP : (0 < v2 *d v1) => [v2v1|].
-  rewrite enormZ gtr0_norm; last first.
+  rewrite enormZ gtr0_norm.
     by rewrite dotmulZv mulr_gt0 // invr_gt0 enorm_gt0.
   rewrite norm_normalize // mulr1 vec_angle_axialcomp //.
-  rewrite dotmul_cos norm_normalize // mul1r vec_angleZv; last first.
+  rewrite dotmul_cos norm_normalize // mul1r vec_angleZv.
     by rewrite invr_gt0 enorm_gt0.
   rewrite [in RHS]mulrA (vec_angleC v1) -expr2 -mulrA -expr2 exprMn.
   by rewrite mulr2n opprD addrA subrK sin2cos2 mulrBr mulr1.
 rewrite -leNgt le_eqVlt => /orP[|v2v1].
   rewrite {1}dotmul_cos -mulrA mulf_eq0 enorm_eq0 (negbTE v20) /=.
   rewrite mulf_eq0 enorm_eq0 (negbTE v10) /= => /eqP Hcos.
-  rewrite axialcomp_dotmul; last by rewrite dotmul_cos Hcos mulr0.
+  rewrite axialcomp_dotmul; first by rewrite dotmul_cos Hcos mulr0.
   rewrite enorm0 mulr0 mul0r expr0n mul0rn addr0 subr0.
   by rewrite -(sqr_normr (sin _)) vec_angleC cos0sin1 ?expr1n ?mulr1.
-rewrite vec_anglevZN //; last first.
+rewrite vec_anglevZN //.
   by rewrite /normalize dotmulZv pmulr_rlt0 // invr_gt0 enorm_gt0.
 rewrite cos_vec_anglevN // ?normalize_eq0 //.
 rewrite enorm_axialcomp // !(mulrN,mulNr,opprK,sqrrN).
@@ -840,7 +841,7 @@ Lemma law_of_sines_point (p1 p2 p : 'rV[T]_3) : ~~ tricolinear p1 p2 p ->
   sin (vec_angle (p2 - p1) (p2 - p)) / `|p1 - p|_e.
 Proof.
 move=> H v1 v2.
-rewrite (_ : p2 - p1 = v2 - v1); last by rewrite /v1 /v2 opprB addrA subrK.
+rewrite (_ : p2 - p1 = v2 - v1); first by rewrite /v1 /v2 opprB addrA subrK.
 apply law_of_sines_vector.
 apply: contra H.
 by rewrite tricolinear_perm 2!tricolinear_rot /tricolinear /v1 /v2 colinear_sym.
@@ -1033,7 +1034,7 @@ have Ht' : t' = interpoint_t l1 l2.
   move/(congr1 (fun x => x *d (v1 *v v2))).
   rewrite dotmulZv.
   move/(congr1 (fun x => x / ((v1 *v v2) *d (v1 *v v2)))).
-  rewrite -mulrA divrr ?mulr1; first by rewrite -dot_crossmulC crossmul_triple.
+  rewrite -mulrA divrr ?mulr1; last by rewrite -dot_crossmulC crossmul_triple.
   by rewrite unitfE dotmulvv0.
 have Hs' : s' = interpoint_s l1 l2.
   have : s' *: (v1 *v v2) = (\pt( l2) - \pt( l1 )) *v v1.
@@ -1044,7 +1045,7 @@ have Hs' : s' = interpoint_s l1 l2.
   move/(congr1 (fun x => x *d (v1 *v v2))).
   rewrite dotmulZv.
   move/(congr1 (fun x => x / ((v1 *v v2) *d (v1 *v v2)))).
-  rewrite -mulrA divrr ?mulr1; first by rewrite -dot_crossmulC crossmul_triple.
+  rewrite -mulrA divrr ?mulr1; last by rewrite -dot_crossmulC crossmul_triple.
   by rewrite unitfE dotmulvv0.
 by rewrite /t /s -Ht' -Hs'.
 Qed.


### PR DESCRIPTION
- updated rewrite order
- qualified import of algebra tactics
- updated opam description